### PR TITLE
Implement serde.toTOML and start string.nix

### DIFF
--- a/serde.nix
+++ b/serde.nix
@@ -1,4 +1,8 @@
-{
+let
+  string = import ./string.nix;
+  list = import ./list.nix;
+  set = import ./set.nix;
+in rec {
   /* toJSON :: Set -> JSON
   */
   toJSON = builtins.toJSON;
@@ -10,7 +14,80 @@
 
   /* toTOML :: Set -> TOML
   */
-  toTOML = throw "implement toTOML";
+  toTOML =
+    let
+      # Escape a TOML key; if it is a string that's a valid identifier, we don't
+      # need to add quotes
+      tomlEscapeKey = val:
+        # Identifier regex taken from https://toml.io/en/v1.0.0-rc.1#keyvalue-pair
+        if builtins.isString val && builtins.match "[A-Za-z0-9_-]+" val != null
+          then val
+          else toJSON val;
+
+      # Escape a TOML value
+      tomlEscapeValue = toJSON;
+
+      # Render a TOML value that appears on the right hand side of an equals
+      tomlValue = v:
+        if builtins.isList v
+          then "[${string.concatMapSep ", " tomlValue v}]"
+        else if builtins.isAttrs v
+          then "{${string.concatMapSep ", " ({ name, value }: tomlKV name value) (set.toList v)}}"
+        else tomlEscapeValue v;
+
+      # Render an inline TOML "key = value" pair
+      tomlKV = k: v: "${tomlEscapeKey k} = ${tomlValue v}";
+
+      # Turn a prefix like [ "foo" "bar" ] into an escaped header value like
+      # "foo.bar"
+      dots = string.concatMapSep "." tomlEscapeKey;
+
+      # Render a TOML table with a header
+      tomlTable = oldPrefix: k: v:
+        let
+          prefix = oldPrefix ++ [k];
+          rest = go (prefix ++ [k]) v;
+        in "[${dots prefix}]" + string.optional (rest != "") "\n${rest}";
+
+      # Render a TOML array of attrsets using [[]] notation. 'subtables' should
+      # be a list of attrsets.
+      tomlTableArray = oldPrefix: k: subtables:
+        let prefix = oldPrefix ++ [k];
+        in string.concatMapSep "\n\n" (v:
+          let rest = go prefix v;
+          in "[[${dots prefix}]]" + string.optional (rest != "") "\n${rest}") subtables;
+
+      # Wrap a string in a list, yielding the empty list if the string is empty
+      optionalNonempty = str: list.optional (str != "") str;
+
+      # Render an attrset into TOML; when nested, 'prefix' will be a list of the
+      # keys we're currently in
+      go = prefix: attrs:
+        let
+          attrList = set.toList attrs;
+
+          # Render values that are objects using tables
+          tableSplit = list.partition ({ value, ... }: builtins.isAttrs value) attrList;
+          tablesToml = string.concatMapSep "\n\n"
+            ({ name, value }: tomlTable prefix name value)
+            tableSplit._0;
+
+          # Use [[]] syntax only on arrays of attrsets
+          tableArraySplit = list.partition
+            ({ value, ... }: builtins.isList value && value != [] && list.all builtins.isAttrs value)
+            tableSplit._1;
+          tableArraysToml = string.concatMapSep "\n\n"
+            ({ name, value }: tomlTableArray prefix name value)
+            tableArraySplit._0;
+
+          # Everything else becomes bare "key = value" pairs
+          pairsToml = string.concatMapSep "\n" ({ name, value }: tomlKV name value) tableArraySplit._1;
+        in string.concatSep "\n\n" (list.concatMap optionalNonempty [
+          pairsToml
+          tablesToml
+          tableArraysToml
+        ]);
+    in go [];
 
   /* @partial
      fromTOML :: TOML -> Set

--- a/set.nix
+++ b/set.nix
@@ -52,4 +52,8 @@ rec {
       empty = ap.pure empty;
       assign = k: v: r: ap.lift2 identity (ap.map (assign k) (f v)) (traverse ap f r);
     };
+
+  /* toList :: set -> [(key, value)]
+  */
+  toList = s: list.map (k: { name = k; value = s.${k}; }) (keys s);
 }

--- a/string.nix
+++ b/string.nix
@@ -1,0 +1,132 @@
+let
+  list = import ./list.nix;
+in rec {
+
+  /* Take a substring of a string at an offset with a given length
+     substring :: int -> int -> string -> string
+  */
+  substring = builtins.substring;
+
+  /* length :: string -> int
+  */
+  length = builtins.stringLength;
+
+  /* Replace all occurrences of each string in the first list with the
+     corresponding string in the second list
+
+     replace :: [string] -> [string] -> string -> string
+  */
+  replace = builtins.replaceStrings;
+
+  /* concat :: [string] -> string
+  */
+  concat = concatSep "";
+
+  /* concatSep :: string -> [string] -> string
+  */
+  concatSep = builtins.concatStringsSep;
+
+  /* concatMap :: (a -> string) -> [a] -> string
+  */
+  concatMap = f: strs: concat (list.map f strs);
+
+  /* concatMapSep :: string -> (a -> string) -> [a] -> string
+  */
+  concatMapSep = sep: f: strs: concatSep sep (list.map f strs);
+
+  /* concatImap :: (int -> a -> string) -> [a] -> string
+  */
+  concatImap = f: strs: concat (list.imap f strs);
+
+  /* concatImapSep :: string -> (int -> a -> string) -> [a] -> string
+  */
+  concatImapSep = sep: f: strs: concatSep sep (list.imap f strs);
+
+  /* toChars :: string -> [string]
+  */
+  toChars = str: list.generate (length str) (i: substring i 1 str);
+
+  /* Map over a string, applying a function to each character
+     map :: (string -> string) -> string -> string
+  */
+  map = f: str: concatMap f (toChars str);
+
+  /* Backslash-escape the chars in the given list
+     escape :: [string] -> string -> string
+  */
+  escape = chars: replace chars (list.map (c: "\\${c}") chars);
+
+  /* Escape an argument to be suitable to pass to the shell
+     escapeShellArgs :: string -> string
+  */
+  escapeShellArg = arg: "'${replace ["'"] ["'\\''"] (toString arg)}'";
+
+  /* Turn a string into a Nix expression representing that string
+  */
+  escapeNixString = str: escape ["$"] (builtins.toJSON str);
+
+  /* hasPrefix :: string -> string -> bool
+  */
+  hasPrefix = pre: str:
+    let
+      strLen = length str;
+      preLen = length pre;
+    in preLen <= strLen && substring 0 preLen str == pre;
+
+  /* hasSuffix :: string -> string -> bool
+  */
+  hasSuffix = suf: str:
+    let
+      strLen = length str;
+      sufLen = length suf;
+    in sufLen <= strLen && substring (length str - sufLen) sufLen str == suf;
+
+  /* hasInfix :: string -> string -> bool
+  */
+  hasInfix = infix: str:
+    let
+      infixLen = length infix;
+      strLen = length str;
+      go = i:
+        if i > strLen - infixLen
+          then false
+        else substring i infixLen str == infix || go (i + 1);
+    in infixLen <= strLen && go 0;
+
+  /* removePrefix :: string -> string -> string
+  */
+  removePrefix = pre: str:
+    let
+      preLen = length pre;
+      strLen = length str;
+    in if hasPrefix pre str
+      then substring preLen (strLen - preLen) str
+      else str;
+
+  /* removeSuffix :: string -> string -> string
+  */
+  removeSuffix = suf: str:
+    if hasSuffix suf str
+      then substring 0 (length str - length suf) str
+      else str;
+
+  /* optional :: bool -> string -> string
+  */
+  optional = b: str: if b then str else "";
+
+  /* lowerChars :: string
+  */
+  lowerChars = "abcdefghijklmnopqrstuvwxyz";
+
+  /* upperChars :: string
+  */
+  upperChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+  /* toLower :: string -> string
+  */
+  toLower = replace upperChars lowerChars;
+
+  /* toUpper :: string -> string
+  */
+  toUpper = replace lowerChars upperChars;
+}


### PR DESCRIPTION
Initial implementation of `serde.toTOML` to dump nix values to relatively human-readable TOML.

Also creates `string.nix` and adds many functions from `nixpkgs.lib.strings`, though qualified function names like `stringLength` are often simply changed to `string.length`.

There may still be lingering bugs, but it seems to work pretty well. Feel free to comment on anything that doesn't adhere to your preferred style conventions. The naming conventions of `set.toList` may need to be changed.