### PR TITLE
Fix some bugs introduced by #1

### DIFF
--- a/serde.nix
+++ b/serde.nix
@@ -46,7 +46,7 @@ in rec {
       tomlTable = oldPrefix: k: v:
         let
           prefix = oldPrefix ++ [k];
-          rest = go (prefix ++ [k]) v;
+          rest = go prefix v;
         in "[${dots prefix}]" + string.optional (rest != "") "\n${rest}";
 
       # Render a TOML array of attrsets using [[]] notation. 'subtables' should

--- a/string.nix
+++ b/string.nix
@@ -44,7 +44,7 @@ in rec {
 
   /* toChars :: string -> [string]
   */
-  toChars = str: list.generate (length str) (i: substring i 1 str);
+  toChars = str: list.generate (i: substring i 1 str) (length str);
 
   /* Map over a string, applying a function to each character
      map :: (string -> string) -> string -> string
@@ -114,13 +114,13 @@ in rec {
   */
   optional = b: str: if b then str else "";
 
-  /* lowerChars :: string
+  /* lowerChars :: [string]
   */
-  lowerChars = "abcdefghijklmnopqrstuvwxyz";
+  lowerChars = toChars "abcdefghijklmnopqrstuvwxyz";
 
-  /* upperChars :: string
+  /* upperChars :: [string]
   */
-  upperChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  upperChars = toChars "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
   /* toLower :: string -> string
   */


### PR DESCRIPTION
Fixes a couple of bugs that were introduced by refactoring when making #1, including occasionally double-nesting keys in the headers of nested TOML.

Being able to write tests would probably be nice