### PR TITLE
Add maybe monoid, fix min/max/first/last

### DIFF
--- a/monoid.nix
+++ b/monoid.nix
@@ -2,27 +2,22 @@ with rec {
   function = import ./function.nix;
   inherit (function) compose id flip;
 
-  list = import ./list.nix;
-
   semigroup = import ./semigroup.nix;
+
+  imports = {
+    list = import ./list.nix;
+    string = import ./string.nix;
+  };
 };
 
-{
-  first = semigroup.first // {
-    empty = null;
-  };
+rec {
+  first = maybe semigroup.first;
 
-  last = semigroup.last // {
-    empty = null;
-  };
+  last = maybe semigroup.last;
 
-  min = semigroup.min // {
-    empty = null;
-  };
+  min = maybe semigroup.min;
 
-  max = semigroup.max // {
-    empty = max;
-  };
+  max = maybe semigroup.max;
 
   dual = monoid: semigroup.dual monoid // {
     empty = monoid.empty;
@@ -40,5 +35,13 @@ with rec {
     empty = false;
   };
 
-  list = list.monoid;
+  list = imports.list.monoid;
+
+  string = imports.string.monoid;
+
+  /* 'maybe' recovers a monoid from a semigroup by adding 'null' as the empty element.
+  */
+  maybe = sg: semigroup.maybe sg // {
+    empty = null;
+  };
 }

--- a/semigroup.nix
+++ b/semigroup.nix
@@ -2,7 +2,10 @@ with rec {
   function = import ./function.nix;
   inherit (function) compose id flip;
 
-  list = import ./list.nix;
+  imports = {
+    list = import ./list.nix;
+    string = import ./string.nix;
+  };
 };
 
 {
@@ -44,5 +47,20 @@ with rec {
     append = x: y: x || y;
   };
 
-  list = list.semigroup;
+  list = imports.list.semigroup;
+
+  string = imports.string.semigroup;
+
+  /* 'maybe' recovers a monoid from a semigroup by adding 'null' as the empty
+     element. The semigroup's append will simply discard nulls in favor of other
+     elements.
+  */
+  maybe = semigroup: {
+    append = x: y:
+      if x == null
+        then y
+      else if y == null
+        then x
+      else semigroup.append x y;
+  };
 }


### PR DESCRIPTION
Add a `maybe` monoid to recover a monoid from a semigroup. This is used to fix the broken `min`/`max`/`first`/`last` monoids.

Also adds the `string` semigroup and monoid.