### PR TITLE
Add bitwise and other num functions

### DIFF
--- a/num.nix
+++ b/num.nix
@@ -321,7 +321,7 @@ in rec {
   /* toHexString :: int -> string
   */
   toHexString = x:
-    let toHexDigit = string.index "0123456789ABCDEF";
+    let toHexDigit = string.index "0123456789abcdef";
     in string.concatMap toHexDigit (toBaseDigits 16 x);
 
   /* gcd :: int -> int -> int

--- a/num.nix
+++ b/num.nix
@@ -44,17 +44,18 @@ in rec {
     then y
     else x;
 
-  /* compare :: number -> number -> int
+  /* compare :: number -> number -> "LT" | "EQ" | "GT"
 
-     Compares two numbers and returns -1 if the first is less than the second, 0
-     if they are equal, or 1 if the first is greater than the second.
+     Compares two numbers and returns `"LT"` if the first is less than the
+     second, `"EQ"` if they are equal, or `"GT"` if the first is greater than
+     the second.
   */
   compare = x: y:
     if x < y
-      then -1
+      then "LT"
     else if x > y
-      then 1
-    else 0;
+      then "GT"
+    else "EQ";
 
   /* quot :: integer -> integer -> integer
 

--- a/num.nix
+++ b/num.nix
@@ -311,4 +311,21 @@ in rec {
   toHexString = x:
     let toHexDigit = string.index "0123456789ABCDEF";
     in string.concatMap toHexDigit (toBaseDigits 16 x);
+
+  /* gcd :: int -> int -> int
+
+     Computes the greatest common divisor of two integers.
+  */
+  gcd = x: y:
+    let gcd' = a: b: if b == 0 then a else gcd' b (rem a b);
+    in gcd' (abs x) (abs y);
+
+  /* lcm :: int -> int -> int
+
+     Computes the least common multiple of two integers.
+  */
+  lcm = x: y:
+    if x == 0 || y == 0
+    then 0
+    else abs (quot x (gcd x y) * y);
 }

--- a/num.nix
+++ b/num.nix
@@ -127,7 +127,7 @@ in rec {
 
   pi = 3.141592653589793238;
 
-  /* toFloat :: int -> float
+  /* toFloat :: number -> float
 
      Converts an integer to a floating-point number.
   */

--- a/num.nix
+++ b/num.nix
@@ -349,17 +349,28 @@ in rec {
     let
       # table of (bit n) for 0 <= n <= (sizeof(int) - 1)
       powtab = [
-        1 2 4 8 16 32 64 128 256 512 1024 2048 4096 8192 16384 32768 65536 131072
-        262144 524288 1048576 2097152 4194304 8388608 16777216 33554432 67108864
-        134217728 268435456 536870912 1073741824 2147483648 4294967296 8589934592
-        17179869184 34359738368 68719476736 137438953472 274877906944 549755813888
-        1099511627776 2199023255552 4398046511104 8796093022208 17592186044416
-        35184372088832 70368744177664 140737488355328 281474976710656
-        562949953421312 1125899906842624 2251799813685248 4503599627370496
-        9007199254740992 18014398509481984 36028797018963968 72057594037927936
-        144115188075855872 288230376151711744 576460752303423488
-        1152921504606846976 2305843009213693952 4611686018427387904
-        (9223372036854775807 + 1)
+        1 2 4 8 16 32 64 128 256 512 1024 2048 4096 8192 16384 32768 65536
+        131072 262144 524288 1048576 2097152 4194304 8388608 16777216 33554432
+        67108864 134217728 268435456 536870912 1073741824 2147483648 4294967296
+        8589934592 17179869184 34359738368 68719476736 137438953472 274877906944
+        549755813888 1099511627776 2199023255552 4398046511104 8796093022208
+        17592186044416 35184372088832 70368744177664 140737488355328
+        281474976710656 562949953421312 1125899906842624 2251799813685248
+        4503599627370496 9007199254740992 18014398509481984 36028797018963968
+        72057594037927936 144115188075855872 288230376151711744
+        576460752303423488 1152921504606846976 2305843009213693952
+        4611686018427387904 (9223372036854775807 + 1)
+      ];
+      # De Bruijn multiplication lookup table, used for bitScanReverse
+      debruijn = [
+        0 47 1 56 48 27 2 60
+        57 49 41 37 28 16 3 61
+        54 58 35 52 50 42 21 44
+        38 32 29 23 17 11 4 62
+        46 55 26 59 40 36 15 53
+        34 51 20 43 31 22 10 45
+        25 39 14 33 19 30 9 24
+        13 18 8 12 7 6 5 63
       ];
     in rec {
       /* bitSize :: int
@@ -564,5 +575,64 @@ in rec {
           x5 = (bitAnd x4 281470681808895) + shiftRU (bitAnd x4 (-281470681808896)) 16;
           x6 = (bitAnd x5 4294967295) + shiftRU (bitAnd x5 (-4294967296)) 32;
         in x6;
+
+      /* bitScanForward :: int -> int
+
+         Computes the index of the lowest set bit in the 2's complement
+         binary representation of the given integer, where index 0 corresponds
+         to the least-significant bit. If there are no bits set, the index will
+         be equal to `num.bits.bitSize`.
+      */
+      bitScanForward = x0:
+        if x0 == 0
+        then 64
+        else popCount (bitAnd x0 (-x0) - 1);
+
+      /* countTrailingZeros :: int -> int
+
+         Computes the number of zeros after (in place values less than) the
+         lowest set bit in the 2's complement binary representation of the given
+         integer, where index 0 corresponds to the least-significant bit. If
+         there are no bits set, the result will be equal to `num.bits.bitSize`.
+      */
+      countTrailingZeros = x0:
+        if x0 == 0
+          then 64
+          else bitScanForward x0;
+
+      /* bitScanReverse :: int -> int
+
+         Computes the index of the highest set bit in the 2's complement
+         representation of the given integer, where index 0 corresponds to the
+         least-significant bit. If there are no bits set, the index will be
+         equal to `num.bits.bitSize`.
+      */
+      bitScanReverse = x0:
+        let
+          x1 = bitOr x0 (x0 / 2);
+          x2 = bitOr x1 (x1 / 4);
+          x3 = bitOr x2 (x2 / 16);
+          x4 = bitOr x3 (x3 / 256);
+          x5 = bitOr x4 (x4 / 65536);
+          x6 = bitOr x5 (x5 / 4294967296);
+        in
+          if x0 == 0
+            then 64
+          else if x0 < 0 # MSB is set
+            then 63
+          else list.index debruijn (shiftRU (x6 * 285870213051386505) 58);
+
+      /* countLeadingZeros :: int -> int
+
+         Computes the number of zeros before (in place values greater than) the
+         highest set bit in the 2's complement binary representation of the
+         given integer, where index 0 corresponds to the least-significant bit.
+         If there are no bits set, the result will be equal to
+         `num.bits.bitSize`.
+      */
+      countLeadingZeros = x0:
+        if x0 == 0
+          then 64
+          else bitXor (bitScanReverse x0) 63;
     };
 }

--- a/num.nix
+++ b/num.nix
@@ -134,6 +134,14 @@ in rec {
 
   sin = t:
     let x = toFloat t;
+        x2 = x * x;
+        x3 = x2 * x;
+        x5 = x2 * x3;
+        x7 = x2 * x5;
+        x9 = x2 * x7;
+        x11 = x2 * x9;
+        x13 = x2 * x11;
+        x15 = x2 * x13;
         _3fac = 6.0;
         _5fac = 120.0;
         _7fac = 5040.0;
@@ -142,16 +150,24 @@ in rec {
         _13fac = 6227020800.0;
         _15fac = 1307674368000.0;
     in x
-       - pow x 3 / _3fac
-       + pow x 5 / _5fac
-       - pow x 7 / _7fac
-       + pow x 9 / _9fac
-       - pow x 11 / _11fac
-       + pow x 13 / _13fac
-       - pow x 15 / _15fac;
+       - x3 / _3fac
+       + x5 / _5fac
+       - x7 / _7fac
+       + x9 / _9fac
+       - x11 / _11fac
+       + x13 / _13fac
+       - x15 / _15fac;
 
   cos = t:
     let x = toFloat t;
+        x2 = x * x;
+        x4 = x2 * x2;
+        x6 = x2 * x4;
+        x8 = x2 * x6;
+        x10 = x2 * x8;
+        x12 = x2 * x10;
+        x14 = x2 * x12;
+        x16 = x2 * x14;
         _2fac = 2.0;
         _4fac = 24.0;
         _6fac = 720.0;
@@ -161,14 +177,14 @@ in rec {
         _14fac = 87178291200.0;
         _16fac = 20922789888000.0;
     in 1.0
-       - pow x 2 / _2fac
-       + pow x 4 / _4fac
-       - pow x 6 / _6fac
-       + pow x 8 / _8fac
-       - pow x 10 / _10fac
-       + pow x 12 / _12fac
-       - pow x 14 / _14fac
-       + pow x 16 / _16fac;
+       - x2 / _2fac
+       + x4 / _4fac
+       - x6 / _6fac
+       + x8 / _8fac
+       - x10 / _10fac
+       + x12 / _12fac
+       - x14 / _14fac
+       + x16 / _16fac;
 
   /*
   type Complex = { realPart :: float, imagPart :: float }

--- a/test.nix
+++ b/test.nix
@@ -310,6 +310,17 @@ let
         (assertEqual (num.toHexString 4660) "1234")
         (assertEqual (num.toHexString 11259375) "ABCDEF")
       ];
+      gcd = string.unlines [
+        (assertEqual (num.gcd 0 0) 0)
+        (assertEqual (num.gcd 1 1) 1)
+        (assertEqual (num.gcd (-17289472) 198264) 8)
+      ];
+      lcm = string.unlines [
+        (assertEqual (num.lcm 0 0) 0)
+        (assertEqual (num.lcm 1 0) 0)
+        (assertEqual (num.lcm 1 1) 1)
+        (assertEqual (num.lcm 127 (-928)) 117856)
+      ];
     };
     list = section "std.list" {
       laws = string.unlines [

--- a/test.nix
+++ b/test.nix
@@ -198,9 +198,12 @@ let
         (assertEqual (num.max 5 (-3)) 5)
       ];
       compare = string.unlines [
-        (assertEqual (num.compare (-3) 5) (-1))
-        (assertEqual (num.compare 5 5) 0)
-        (assertEqual (num.compare 5 (-3)) 1)
+        (assertEqual (num.compare (-3) 5) "LT")
+        (assertEqual (num.compare 5 5) "EQ")
+        (assertEqual (num.compare 5 (-3)) "GT")
+        (assertEqual (num.compare num.minInt num.maxInt) "LT")
+        (assertEqual (num.compare num.minInt num.minInt) "EQ")
+        (assertEqual (num.compare num.maxInt num.minInt) "GT")
       ];
       quot = string.unlines [
         (assertEqual (num.quot 18 7) 2)

--- a/test.nix
+++ b/test.nix
@@ -461,6 +461,37 @@ let
         (assertEqual (num.bits.popCount (-6148914691236517206)) (num.bits.bitSize / 2))
         (assertEqual (num.bits.popCount 3689348814741910323) (num.bits.bitSize / 2))
       ];
+      bitScanForward =
+        let
+          case = n: assertEqual (num.bits.bitScanForward (num.bits.bit n)) n;
+          singleBitTests = string.unlines (list.map case (list.range 0 num.bits.bitSize));
+        in string.unlines [
+          singleBitTests
+          (assertEqual (num.bits.bitScanForward 5) 0)
+          (assertEqual (num.bits.bitScanForward (num.bits.bitOr (num.bits.bit (num.bits.bitSize - 1)) 1)) 0)
+          (assertEqual (num.bits.bitScanForward (-1)) 0)
+        ];
+      countTrailingZeros =
+        let
+          case = n: assertEqual (num.bits.countTrailingZeros (num.bits.bit n)) n;
+        in string.unlines (list.map case (list.range 0 num.bits.bitSize));
+      bitScanReverse =
+        let
+          case = n: assertEqual (num.bits.bitScanReverse (num.bits.bit n)) n;
+          singleBitTests = string.unlines (list.map case (list.range 0 num.bits.bitSize));
+        in string.unlines [
+          singleBitTests
+          (assertEqual (num.bits.bitScanReverse 5) 2)
+          (assertEqual (num.bits.bitScanReverse (num.bits.bitOr (num.bits.bit (num.bits.bitSize - 1)) 1)) (num.bits.bitSize - 1))
+          (assertEqual (num.bits.bitScanReverse (-1)) (num.bits.bitSize - 1))
+        ];
+      countLeadingZeros =
+        let
+          case = n:
+            assertEqual
+              (num.bits.countLeadingZeros (num.bits.bit n))
+              (if n == 64 then 64 else num.bits.bitSize - n - 1);
+        in string.unlines (list.map case (list.range 0 num.bits.bitSize));
     };
     list = section "std.list" {
       laws = string.unlines [

--- a/test.nix
+++ b/test.nix
@@ -307,7 +307,7 @@ let
       toHexString = string.unlines [
         (assertEqual (num.toHexString 0) "0")
         (assertEqual (num.toHexString 4660) "1234")
-        (assertEqual (num.toHexString 11259375) "ABCDEF")
+        (assertEqual (num.toHexString 11259375) "abcdef")
       ];
       gcd = string.unlines [
         (assertEqual (num.gcd 0 0) 0)

--- a/test.nix
+++ b/test.nix
@@ -178,6 +178,139 @@ let
         (assertEqual (ifThenElse false "left" "right") "right")
       ];
     };
+    num = section "std.num" {
+      bitNot = string.unlines [
+        (assertEqual (num.bitNot 0) (-1))
+        (assertEqual (num.bitNot 5) (-6))
+      ];
+      negate = assertEqual (num.negate 5) (-5);
+      abs = string.unlines [
+        (assertEqual (num.abs (-5)) 5)
+        (assertEqual (num.abs 5) 5)
+      ];
+      signum = string.unlines [
+        (assertEqual (num.signum 5) 1)
+        (assertEqual (num.signum 0) 0)
+        (assertEqual (num.signum (-5)) (-1))
+      ];
+      min = string.unlines [
+        (assertEqual (num.min (-3) 5) (-3))
+        (assertEqual (num.min 5 (-3)) (-3))
+      ];
+      max = string.unlines [
+        (assertEqual (num.max (-3) 5) 5)
+        (assertEqual (num.max 5 (-3)) 5)
+      ];
+      compare = string.unlines [
+        (assertEqual (num.compare (-3) 5) (-1))
+        (assertEqual (num.compare 5 5) 0)
+        (assertEqual (num.compare 5 (-3)) 1)
+      ];
+      quot = string.unlines [
+        (assertEqual (num.quot 18 7) 2)
+        (assertEqual (num.quot 18 (-7)) (-2))
+        (assertEqual (num.quot (-18) 7) (-2))
+        (assertEqual (num.quot (-18) (-7)) 2)
+      ];
+      rem = string.unlines [
+        (assertEqual (num.rem 18 7) 4)
+        (assertEqual (num.rem 18 (-7)) 4)
+        (assertEqual (num.rem (-18) 7) (-4))
+        (assertEqual (num.rem (-18) (-7)) (-4))
+      ];
+      div = string.unlines [
+        (assertEqual (num.div 18 7) 2)
+        (assertEqual (num.div 18 (-7)) (-3))
+        (assertEqual (num.div (-18) 7) (-3))
+        (assertEqual (num.div (-18) (-7)) 2)
+      ];
+      mod = string.unlines [
+        (assertEqual (num.mod 18 7) 4)
+        (assertEqual (num.mod 18 (-7)) (-3))
+        (assertEqual (num.mod (-18) 7) 3)
+        (assertEqual (num.mod (-18) (-7)) (-4))
+      ];
+      quotRem = assertEqual (num.quotRem (-18) 7) { _0 = (-2); _1 = (-4); };
+      divMod = assertEqual (num.divMod (-18) 7) { _0 = (-3); _1 = 3; };
+      even = string.unlines [
+        (assertEqual (num.even (-1)) false)
+        (assertEqual (num.even 0) true)
+        (assertEqual (num.even 1) false)
+      ];
+      odd = string.unlines [
+        (assertEqual (num.odd (-1)) true)
+        (assertEqual (num.odd 0) false)
+        (assertEqual (num.odd 1) true)
+      ];
+      fac = string.unlines [
+        (assertEqual (num.fac 0) 1)
+        (assertEqual (num.fac 5) 120)
+      ];
+      pow = string.unlines [
+        (assertEqual (num.pow 0 10) 1)
+        (assertEqual (num.pow 1 10) 1)
+        (assertEqual (num.pow 10 0) 1)
+        (assertEqual (num.pow 10 1) 10)
+        (assertEqual (num.pow 10 3) 1000)
+      ];
+      toFloat = assertEqual (num.toFloat 5) 5.0;
+      truncate = string.unlines [
+        (assertEqual (num.truncate 1.5) 1)
+        (assertEqual (num.truncate (-1.5)) (-1))
+      ];
+      floor = string.unlines [
+        (assertEqual (num.floor 1.5) 1)
+        (assertEqual (num.floor (-1.5)) (-2))
+      ];
+      ceil = string.unlines [
+        (assertEqual (num.ceil 1.5) 2)
+        (assertEqual (num.ceil (-1.5)) (-1))
+      ];
+      round = string.unlines [
+        (assertEqual (num.round 1.5) 2)
+        (assertEqual (num.round 1.3) 1)
+        (assertEqual (num.round 1.0) 1)
+        (assertEqual (num.round (-1.5)) (-2))
+        (assertEqual (num.round (-1.3)) (-1))
+        (assertEqual (num.round (-1.0)) (-1))
+      ];
+      tryParseInt = string.unlines [
+        (assertEqual (num.tryParseInt "foo") null)
+        (assertEqual (num.tryParseInt "1.0") null)
+        (assertEqual (num.tryParseInt "0") 0)
+        (assertEqual (num.tryParseInt "05") null)
+        (assertEqual (num.tryParseInt "-5") (-5))
+        (assertEqual (num.tryParseInt "") null)
+        (assertEqual (num.tryParseInt "-") null)
+      ];
+      parseInt = assertEqual (num.parseInt "-5") (-5);
+      tryParseFloat = string.unlines [
+        (assertEqual (num.tryParseFloat "foo") null)
+        (assertEqual (num.tryParseFloat "-1.80") (-1.8))
+        (assertEqual (num.tryParseFloat "0.0") 0.0)
+        (assertEqual (num.tryParseFloat "0") 0.0)
+        (assertEqual (num.tryParseFloat "0.") null)
+        (assertEqual (num.tryParseFloat ".0") null)
+        (assertEqual (num.tryParseFloat ".") null)
+        (assertEqual (num.tryParseFloat "-01.05e-2") null)
+        (assertEqual (num.tryParseFloat "-1.05e-2") ((-1.05) / 100))
+      ];
+      parseFloat = assertEqual (num.parseFloat "-1.80") (-1.8);
+      toBaseDigits = string.unlines [
+        (assertEqual (num.toBaseDigits 16 4660) [ 1 2 3 4 ])
+        (assertEqual (num.toBaseDigits 2 85) [ 1 0 1 0 1 0 1 ])
+        (assertEqual (num.toBaseDigits 20 0) [ 0 ])
+      ];
+      fromBaseDigits = string.unlines [
+        (assertEqual (num.fromBaseDigits 2 [ 1 0 1 0 1 0 1 ]) 85)
+        (assertEqual (num.fromBaseDigits 16 [ 1 2 3 4 ]) 4660)
+      ];
+      toHexString = string.unlines [
+        (assertEqual (num.toHexString 0) "0")
+        (assertEqual (num.toHexString 4660) "1234")
+        (assertEqual (num.toHexString 11259375) "ABCDEF")
+      ];
+    };
     list = section "std.list" {
       laws = string.unlines [
         (functor list.functor {

--- a/test.nix
+++ b/test.nix
@@ -179,10 +179,6 @@ let
       ];
     };
     num = section "std.num" {
-      bitNot = string.unlines [
-        (assertEqual (num.bitNot 0) (-1))
-        (assertEqual (num.bitNot 5) (-6))
-      ];
       negate = assertEqual (num.negate 5) (-5);
       abs = string.unlines [
         (assertEqual (num.abs (-5)) 5)
@@ -320,6 +316,150 @@ let
         (assertEqual (num.lcm 1 0) 0)
         (assertEqual (num.lcm 1 1) 1)
         (assertEqual (num.lcm 127 (-928)) 117856)
+      ];
+    };
+    bits = section "std.num.bits" {
+      bitSize = string.unlines [
+        (assertEqual num.maxInt (num.pow 2 (num.bits.bitSize - 1) - 1))
+        (assertEqual num.minInt (- num.pow 2 (num.bits.bitSize - 1)))
+      ];
+      bitAnd = string.unlines [
+        (assertEqual (num.bits.bitAnd 5 3) 1)
+        (assertEqual (num.bits.bitAnd (-1) 6148914691236517205) 6148914691236517205)
+        (assertEqual (num.bits.bitAnd (-6148914691236517206) 6148914691236517205) 0)
+      ];
+      bitOr = string.unlines [
+        (assertEqual (num.bits.bitOr 5 3) 7)
+        (assertEqual (num.bits.bitOr (-1) 6148914691236517205) (-1))
+        (assertEqual (num.bits.bitOr (-6148914691236517206) 6148914691236517205) (-1))
+      ];
+      bitXor = string.unlines [
+        (assertEqual (num.bits.bitXor 5 3) 6)
+        (assertEqual (num.bits.bitXor (-1) 6148914691236517205) (-6148914691236517206))
+        (assertEqual (num.bits.bitXor (-6148914691236517206) 6148914691236517205) (-1))
+      ];
+      bitNot = string.unlines [
+        (assertEqual (num.bits.bitNot 0) (-1))
+        (assertEqual (num.bits.bitNot (-1)) 0)
+        (assertEqual (num.bits.bitNot (-6148914691236517206)) 6148914691236517205)
+      ];
+      bit =
+        let
+          case = n:
+            let
+              # Manually compute 2^n
+              go = acc: m:
+                if m == 0
+                then acc
+                else let r = 2 * acc; in builtins.seq r (go r (m - 1));
+            in assertEqual (num.bits.bit n) (go 1 n);
+        in string.unlines (list.map case (list.range 0 (num.bits.bitSize - 1)));
+      set =
+        let
+          case = n: string.unlines [
+            # Sets cleared bit
+            (assertEqual (num.bits.set 0 n) (num.bits.bit n))
+            # Idempotence on set bit
+            (assertEqual (num.bits.set (num.bits.set 0 n) n) (num.bits.set 0 n))
+          ];
+        in string.unlines (list.map case (list.range 0 (num.bits.bitSize - 1)));
+      clear =
+        let
+          case = n: string.unlines [
+            # Clears set bit
+            (assertEqual (num.bits.clear (-1) n) (num.bits.bitNot (num.bits.bit n)))
+            # Idempotence on cleared bit
+            (assertEqual (num.bits.clear (-1) n) (num.bits.clear (num.bits.clear (-1) n) n))
+          ];
+        in string.unlines (list.map case (list.range 0 (num.bits.bitSize - 1)));
+      toggle =
+        let
+          case = n: string.unlines [
+            # Clears set bit
+            (assertEqual (num.bits.toggle (-1) n) (num.bits.bitNot (num.bits.bit n)))
+            # Sets cleared bit
+            (assertEqual (num.bits.toggle 0 n) (num.bits.bit n))
+          ];
+        in string.unlines (list.map case (list.range 0 (num.bits.bitSize - 1)));
+      test =
+        let
+          case = n: string.unlines [
+            # Set bit
+            (assertEqual (num.bits.test (num.bits.bit n) n) true)
+            # Cleared bit
+            (assertEqual (num.bits.test 0 n) false)
+          ];
+        in string.unlines (list.map case (list.range 0 (num.bits.bitSize - 1)));
+      shiftL = string.unlines [
+        (assertEqual (num.bits.shiftL 5 3) 40)
+        (assertEqual (num.bits.shiftL 0 5) 0)
+        (assertEqual (num.bits.shiftL (-1) 3) (-8))
+        (assertEqual (num.bits.shiftL (-1) 0) (-1))
+        (assertEqual (num.bits.shiftL (-1) num.bits.bitSize) (0))
+        (assertEqual (num.bits.shiftL (num.bits.bit (num.bits.bitSize - 1)) 1) 0)
+        (assertEqual (num.bits.shiftL (-1) (-1)) (-1))
+        (assertEqual (num.bits.shiftL (-1) (-num.bits.bitSize)) (-1))
+      ];
+      shiftLU = string.unlines [
+        (assertEqual (num.bits.shiftLU 5 3) 40)
+        (assertEqual (num.bits.shiftLU 0 5) 0)
+        (assertEqual (num.bits.shiftLU (-1) 3) (-8))
+        (assertEqual (num.bits.shiftLU (-1) 0) (-1))
+        (assertEqual (num.bits.shiftLU (-1) num.bits.bitSize) (0))
+        (assertEqual (num.bits.shiftLU (num.bits.bit (num.bits.bitSize - 1)) 1) 0)
+        (assertEqual (num.bits.shiftLU (-1) (-1)) num.maxInt)
+        (assertEqual (num.bits.shiftLU (-1) (-num.bits.bitSize)) 0)
+      ];
+      shiftR = string.unlines [
+        (assertEqual (num.bits.shiftR 5 3) 0)
+        (assertEqual (num.bits.shiftR 0 5) 0)
+        (assertEqual (num.bits.shiftR (-30) 2) (-8))
+        (assertEqual (num.bits.shiftR (-1) 3) (-1))
+        (assertEqual (num.bits.shiftR (-1) 0) (-1))
+        (assertEqual (num.bits.shiftR (-1) num.bits.bitSize) (-1))
+        (assertEqual (num.bits.shiftR (-1) (-1)) (-2))
+        (assertEqual (num.bits.shiftR (-1) (-num.bits.bitSize)) 0)
+      ];
+      shiftRU = string.unlines [
+        (assertEqual (num.bits.shiftRU 5 3) 0)
+        (assertEqual (num.bits.shiftRU 0 5) 0)
+        (assertEqual (num.bits.shiftRU (-30) 2) 4611686018427387896)
+        (assertEqual (num.bits.shiftRU (-1) 3) 2305843009213693951)
+        (assertEqual (num.bits.shiftRU (-1) 0) (-1))
+        (assertEqual (num.bits.shiftRU (-1) num.bits.bitSize) 0)
+        (assertEqual (num.bits.shiftRU (-1) (-1)) (-2))
+        (assertEqual (num.bits.shiftRU (-1) (-num.bits.bitSize)) 0)
+      ];
+      rotateL = string.unlines [
+        (assertEqual (num.bits.rotateL 5 3) 40)
+        (assertEqual (num.bits.rotateL 0 5) 0)
+        (assertEqual (num.bits.rotateL (-1) 3) (-1))
+        (assertEqual (num.bits.rotateL (-1) 0) (-1))
+        (assertEqual (num.bits.rotateL (-1) (num.bits.bitSize + 5)) (-1))
+        (assertEqual (num.bits.rotateL 15 num.bits.bitSize) 15)
+        (assertEqual (num.bits.rotateL (num.bits.bit (num.bits.bitSize - 1)) 1) 1)
+        (assertEqual (num.bits.rotateL (-1) (-1)) (-1))
+        (assertEqual (num.bits.rotateL 15 (-2)) (-4611686018427387901))
+        (assertEqual (num.bits.rotateL 15 (-num.bits.bitSize)) 15)
+      ];
+      rotateR = string.unlines [
+        (assertEqual (num.bits.rotateR 25 3) 2305843009213693955)
+        (assertEqual (num.bits.rotateR 0 5) 0)
+        (assertEqual (num.bits.rotateR (-1) 3) (-1))
+        (assertEqual (num.bits.rotateR (-1) 0) (-1))
+        (assertEqual (num.bits.rotateR (-1) (num.bits.bitSize + 5)) (-1))
+        (assertEqual (num.bits.rotateR 15 num.bits.bitSize) 15)
+        (assertEqual (num.bits.rotateR 1 1) (num.bits.bit (num.bits.bitSize - 1)))
+        (assertEqual (num.bits.rotateR (-1) (-1)) (-1))
+        (assertEqual (num.bits.rotateR 15 (-2)) 60)
+        (assertEqual (num.bits.rotateR 15 (-num.bits.bitSize)) 15)
+      ];
+      popCount = string.unlines [
+        (assertEqual (num.bits.popCount 0) 0)
+        (assertEqual (num.bits.popCount (-1)) num.bits.bitSize)
+        (assertEqual (num.bits.popCount 6148914691236517205) (num.bits.bitSize / 2))
+        (assertEqual (num.bits.popCount (-6148914691236517206)) (num.bits.bitSize / 2))
+        (assertEqual (num.bits.popCount 3689348814741910323) (num.bits.bitSize / 2))
       ];
     };
     list = section "std.list" {

--- a/test.nix
+++ b/test.nix
@@ -271,25 +271,25 @@ let
         (assertEqual (num.round (-1.0)) (-1))
       ];
       tryParseInt = string.unlines [
-        (assertEqual (num.tryParseInt "foo") null)
-        (assertEqual (num.tryParseInt "1.0") null)
-        (assertEqual (num.tryParseInt "0") 0)
-        (assertEqual (num.tryParseInt "05") null)
-        (assertEqual (num.tryParseInt "-5") (-5))
-        (assertEqual (num.tryParseInt "") null)
-        (assertEqual (num.tryParseInt "-") null)
+        (assertEqual (num.tryParseInt "foo") optional.nothing)
+        (assertEqual (num.tryParseInt "1.0") optional.nothing)
+        (assertEqual (num.tryParseInt "0") (optional.just 0))
+        (assertEqual (num.tryParseInt "05") optional.nothing)
+        (assertEqual (num.tryParseInt "-5") (optional.just (-5)))
+        (assertEqual (num.tryParseInt "") optional.nothing)
+        (assertEqual (num.tryParseInt "-") optional.nothing)
       ];
       parseInt = assertEqual (num.parseInt "-5") (-5);
       tryParseFloat = string.unlines [
-        (assertEqual (num.tryParseFloat "foo") null)
-        (assertEqual (num.tryParseFloat "-1.80") (-1.8))
-        (assertEqual (num.tryParseFloat "0.0") 0.0)
-        (assertEqual (num.tryParseFloat "0") 0.0)
-        (assertEqual (num.tryParseFloat "0.") null)
-        (assertEqual (num.tryParseFloat ".0") null)
-        (assertEqual (num.tryParseFloat ".") null)
-        (assertEqual (num.tryParseFloat "-01.05e-2") null)
-        (assertEqual (num.tryParseFloat "-1.05e-2") ((-1.05) / 100))
+        (assertEqual (num.tryParseFloat "foo") optional.nothing)
+        (assertEqual (num.tryParseFloat "-1.80") (optional.just (-1.8)))
+        (assertEqual (num.tryParseFloat "0.0") (optional.just 0.0))
+        (assertEqual (num.tryParseFloat "0") (optional.just 0.0))
+        (assertEqual (num.tryParseFloat "0.") optional.nothing)
+        (assertEqual (num.tryParseFloat ".0") optional.nothing)
+        (assertEqual (num.tryParseFloat ".") optional.nothing)
+        (assertEqual (num.tryParseFloat "-01.05e-2") optional.nothing)
+        (assertEqual (num.tryParseFloat "-1.05e-2") (optional.just ((-1.05) / 100)))
       ];
       parseFloat = assertEqual (num.parseFloat "-1.80") (-1.8);
       toBaseDigits = string.unlines [


### PR DESCRIPTION
Adds the following num functions:

- `num.bits`, with lots of useful bitwise functions
- Functions for parsing ints and floats
  - Note that these attempt to use a regex to check that `builtins.fromJSON` will succeed so that it doesn't abort; the regexes are kind of flimsy and should be looked over
- Base conversion functions `toBaseDigits`, `fromBaseDigits`, `toHexString`, although more specializations (`fromHexString`, `toBinString`, etc.) are easy to implement
- `div`, `mod`, `quot`, `rem`
  - A big note is that `builtins.div` is actually a quotient, so I've renamed this here (`quot = builtins.div`). I'm open to suggestions about what else these should be named
- `floor`, `ceil`, `round`, `truncate`
- Other misc. numeric functions like `clamp`, `compare`, etc.

Also, it might be useful to further subdivide `num.nix`.
