### PR TITLE
Remove nixpkgs from test.nix

### DIFF
--- a/test.nix
+++ b/test.nix
@@ -1,9 +1,8 @@
+{ system ? builtins.currentSystem
+}:
+
 with { std = import ./default.nix; };
 with std;
-
-with {
-  inherit (import <nixpkgs> {}) stdenv;
-};
 
 let
   section = module: tests: ''
@@ -719,14 +718,14 @@ let
     };
   };
 in
-stdenv.mkDerivation {
-  pname = "nix-std-test";
-  version = import ./version.nix;
-
-  doCheck = true;
-  phases = [ "checkPhase" "installPhase" ];
-
-  checkPhase = string.unlines (builtins.attrValues sections);
-
-  installPhase = "touch $out";
+builtins.derivation {
+  name = "nix-std-test-${import ./version.nix}";
+  inherit system;
+  builder = "/bin/sh";
+  args = [
+    "-c"
+    (string.unlines (builtins.attrValues sections) + ''
+      echo > "$out"
+    '')
+  ];
 }

--- a/test.nix
+++ b/test.nix
@@ -723,10 +723,8 @@ stdenv.mkDerivation {
   pname = "nix-std-test";
   version = import ./version.nix;
 
-  src = ./.;
-
   doCheck = true;
-  phases = [ "unpackPhase" "checkPhase" "installPhase" ];
+  phases = [ "checkPhase" "installPhase" ];
 
   checkPhase = string.unlines (builtins.attrValues sections);
 


### PR DESCRIPTION
Use `builtins.derivation` directly to avoid pulling in `stdenv` from nixpkgs in `test.nix`.

In addition to removing the dependency, this means it can be added to flake checks if we add a `flake.nix`, without having to add nixpkgs as a flake input.

In addition, the old derivation would rebuild every time since `src` wasn't filtered (it shouldn't have been included in the first place), which this fixes.