### PR TITLE
Add flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,33 @@
 {
   description = "No-nixpkgs standard library for the Nix expression language";
 
-  outputs = { self }: {
-    lib = import ./default.nix;
-  };
+  outputs = { self }:
+    let
+      attrsToList = as:
+        builtins.map (n: { name = n; value = as."${n}"; })
+          (builtins.attrNames as);
+      defaultSystems = [
+        "aarch64-linux"
+        "i686-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
+      eachDefaultSystem = f:
+        builtins.foldl'
+          (acc: system:
+            builtins.foldl'
+              (acc: { name, value }:
+                acc // { "${name}" = (acc.${name} or { }) // { "${system}" = value; }; }
+              )
+              acc
+              (attrsToList (f system))
+          )
+          { }
+          defaultSystems;
+    in
+    {
+      lib = import ./default.nix;
+    } // eachDefaultSystem (system: {
+      checks.nix-std-test = import ./test.nix { inherit system; };
+    });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,7 @@
+{
+  description = "No-nixpkgs standard library for the Nix expression language";
+
+  outputs = { self }: {
+    lib = import ./default.nix;
+  };
+}


### PR DESCRIPTION
Adds a simple `flake.nix` to export the lib. Even though flakes aren't stable yet, lots of people are using them, and adding a flake makes it trivial to pull in nix-std.

`test.nix` is included as a check. The systems used for the checks are the default systems from https://github.com/numtide/flake-utils; the `eachDefaultSystem` is the standard way you would write this in a flake that wasn't trying to avoid inputs. Since `test.nix` no longer depends on nixpkgs after #8, the flake doesn't have to take any inputs at all.

The only question I have is whether the root of the library should be under `lib` or under an additional indirection like `lib.std`. For reference, flake-utils exports their library under `lib`, which is what I've tentatively done. home-manager puts their main library under `lib.hm`, but they also have extra things at the top level of `lib`, which explains the indirection.

It's easy to test this on a flake-compatible Nix. For example:

```
nix-repl> nix-std = (builtins.getFlake "github:nprindle/nix-std/add-flake").lib

nix-repl> nix-std.version                                                       
"0.0.0.1"
```

or equivalently:

```
$ nix eval 'github:nprindle/nix-std/add-flake#lib.version'
"0.0.0.1"
```