### PR TITLE
Change nullable -> optional in regex, fix maybe in monoid/semigroup

### DIFF
--- a/applicative.nix
+++ b/applicative.nix
@@ -1,9 +1,11 @@
 with {
   list = import ./list.nix;
   nullable = import ./nullable.nix;
+  optional = import ./optional.nix;
 };
 
 {
   list = list.applicative;
   nullable = nullable.applicative;
+  optional = optional.applicative;
 }

--- a/functor.nix
+++ b/functor.nix
@@ -1,9 +1,11 @@
 with {
   list = import ./list.nix;
   nullable = import ./nullable.nix;
+  optional = import ./optional.nix;
 };
 
 {
   list = list.functor;
   nullable = nullable.functor;
+  optional = optional.functor;
 }

--- a/monad.nix
+++ b/monad.nix
@@ -1,9 +1,11 @@
 with {
   list = import ./list.nix;
   nullable = import ./nullable.nix;
+  optional = import ./optional.nix;
 };
 
 {
   list = list.monad;
   nullable = nullable.monad;
+  optional = optional.monad;
 }

--- a/monoid.nix
+++ b/monoid.nix
@@ -7,17 +7,18 @@ with rec {
   imports = {
     list = import ./list.nix;
     string = import ./string.nix;
+    optional = import ./optional.nix;
   };
 };
 
 rec {
-  first = maybe semigroup.first;
+  first = optional semigroup.first;
 
-  last = maybe semigroup.last;
+  last = optional semigroup.last;
 
-  min = maybe semigroup.min;
+  min = optional semigroup.min;
 
-  max = maybe semigroup.max;
+  max = optional semigroup.max;
 
   dual = monoid: semigroup.dual monoid // {
     empty = monoid.empty;
@@ -39,9 +40,14 @@ rec {
 
   string = imports.string.monoid;
 
-  /* 'maybe' recovers a monoid from a semigroup by adding 'null' as the empty element.
+  /* 'optional' recovers a monoid from a semigroup by adding `optional.nothing`
+     as the empty element.
   */
-  maybe = sg: semigroup.maybe sg // {
+  optional = sg: semigroup.optional sg // {
+    empty = imports.optional.nothing;
+  };
+
+  nullable = sg: semigroup.nullable sg // {
     empty = null;
   };
 }

--- a/nullable.nix
+++ b/nullable.nix
@@ -1,6 +1,7 @@
 with rec {
   function = import ./function.nix;
   inherit (function) id;
+  optional = import ./optional.nix;
 };
 
 /*

--- a/optional.nix
+++ b/optional.nix
@@ -77,4 +77,23 @@ rec {
     if x == nothing
     then con.nothing
     else con.just x.value;
+
+  /* fromNullable :: nullable a -> optional a
+  */
+  fromNullable = x:
+    if x == null
+    then nothing
+    else just x;
+
+  /* toNullable :: optional a -> nullable a
+  */
+  toNullable = x: x.value;
+
+  /* optional a -> bool
+  */
+  isJust = x: x.value != null;
+
+  /* optional a -> bool
+  */
+  isNothing = x: x.value == null;
 }

--- a/semigroup.nix
+++ b/semigroup.nix
@@ -51,11 +51,20 @@ with rec {
 
   string = imports.string.semigroup;
 
-  /* 'maybe' recovers a monoid from a semigroup by adding 'null' as the empty
-     element. The semigroup's append will simply discard nulls in favor of other
-     elements.
+  /* 'optional' recovers a monoid from a semigroup by adding `optional.nothing`
+     as the empty element. The semigroup's append will simply discard nothings
+     in favor of other elements.
   */
-  maybe = semigroup: {
+  optional = semigroup: {
+    append = x: y:
+      if x.value == null
+        then y
+      else if y.value == null
+        then x
+      else { value = semigroup.append x.value y.value; };
+  };
+
+  nullable = semigroup: {
     append = x: y:
       if x == null
         then y

--- a/string.nix
+++ b/string.nix
@@ -317,9 +317,10 @@ rec {
 
   /* count :: string -> string -> int
 
-     Count the number of times a string appears in a larger string.
+     Count the number of times a string appears in a larger string (not counting
+     overlapping).
 
-     > string.count "o" "foobar"
+     > string.count "oo" "foooobar"
      2
   */
   count = needle: str: list.length (regex.allMatches (regex.escape needle) str);

--- a/test.nix
+++ b/test.nix
@@ -332,11 +332,11 @@ let
       foldr = assertEqual 55 (list.foldr builtins.add 0 (list.range 1 10));
       foldl' = assertEqual 3628800 (list.foldl' builtins.mul 1 (list.range 1 10));
       foldMap = string.unlines [
-        (assertEqual 1 (list.foldMap std.monoid.first id (list.range 1 10)))
+        (assertEqual (optional.just 1) (list.foldMap std.monoid.first optional.just (list.range 1 10)))
         (assertEqual 321 ((list.foldMap std.monoid.endo id [ (x: builtins.mul x 3) (x: builtins.add x 7) (x: num.pow x 2) ]) 10))
       ];
       fold = string.unlines [
-        (assertEqual 1 (list.fold std.monoid.first (list.range 1 10)))
+        (assertEqual (optional.just 1) (list.fold std.monoid.first (list.map optional.just (list.range 1 10))))
         (assertEqual 321 ((list.fold std.monoid.endo [ (x: builtins.mul x 3) (x: builtins.add x 7) (x: num.pow x 2) ]) 10))
       ];
       sum = assertEqual 55 (list.sum (list.range 1 10));

--- a/test.nix
+++ b/test.nix
@@ -682,22 +682,22 @@ let
       match = string.unlines [
         (assertEqual
           (regex.match "([[:alpha:]]+)([[:digit:]]+)" "foo123")
-          ["foo" "123"])
+          (optional.just ["foo" "123"]))
         (assertEqual
           (regex.match "([[:alpha:]]+)([[:digit:]]+)" "foobar")
-          null)
+          optional.nothing)
       ];
 
       allMatches = assertEqual (regex.allMatches "[[:digit:]]+" "foo 123 bar 456") ["123" "456"];
 
       firstMatch = string.unlines [
-        (assertEqual (regex.firstMatch "[aeiou]" "foobar") "o")
-        (assertEqual (regex.firstMatch "[aeiou]" "xyzzyx") null)
+        (assertEqual (regex.firstMatch "[aeiou]" "foobar") (optional.just "o"))
+        (assertEqual (regex.firstMatch "[aeiou]" "xyzzyx") optional.nothing)
       ];
 
       lastMatch = string.unlines [
-        (assertEqual (regex.lastMatch "[aeiou]" "foobar") "a")
-        (assertEqual (regex.lastMatch "[aeiou]" "xyzzyx") null)
+        (assertEqual (regex.lastMatch "[aeiou]" "foobar") (optional.just "a"))
+        (assertEqual (regex.lastMatch "[aeiou]" "xyzzyx") optional.nothing)
       ];
 
       split = assertEqual (regex.split "(,)" "1,2,3") ["1" [","] "2" [","] "3"];


### PR DESCRIPTION
Switches the functions in regex that returned nullables to return optionals instead, and fixes a few errors in the docs. Adds a few utility functions to optional to help out.

Also fixes `maybe` in `monoid`/`semigroup`, replacing with `optional` and `nullable` derived monoids/semigroups, and adds the optional instances for functor/applicative/monad to the appropriate files.

I think this is the last major thing to change in the nullable to optional switch, though at some point adding safe versions of partial indexing functions would be nice.