### PR TITLE
Remove nullable monad, move nullable semigroup/monoid to nullable.nix

### DIFF
--- a/monad.nix
+++ b/monad.nix
@@ -1,11 +1,9 @@
 with {
   list = import ./list.nix;
-  nullable = import ./nullable.nix;
   optional = import ./optional.nix;
 };
 
 {
   list = list.monad;
-  nullable = nullable.monad;
   optional = optional.monad;
 }

--- a/monoid.nix
+++ b/monoid.nix
@@ -7,6 +7,7 @@ with rec {
   imports = {
     list = import ./list.nix;
     string = import ./string.nix;
+    nullable = import ./nullable.nix;
     optional = import ./optional.nix;
   };
 };
@@ -40,14 +41,7 @@ rec {
 
   string = imports.string.monoid;
 
-  /* 'optional' recovers a monoid from a semigroup by adding `optional.nothing`
-     as the empty element.
-  */
-  optional = sg: semigroup.optional sg // {
-    empty = imports.optional.nothing;
-  };
+  nullable = imports.nullable.monoid;
 
-  nullable = sg: semigroup.nullable sg // {
-    empty = null;
-  };
+  optional = imports.optional.monoid;
 }

--- a/nullable.nix
+++ b/nullable.nix
@@ -41,4 +41,17 @@ rec {
     if x == null
     then nothing
     else just x;
+
+  semigroup = a: {
+    append = x: y:
+      if x == null
+        then y
+      else if y == null
+        then x
+      else a.append x y;
+  };
+
+  monoid = a: semigroup a // {
+    empty = null;
+  };
 }

--- a/optional.nix
+++ b/optional.nix
@@ -58,15 +58,22 @@ rec {
     };
   };
 
+  /* `optional.semigroup` recovers a monoid from a semigroup by adding
+     `optional.nothing` as the empty element. The semigroup's append will simply
+     discard nothings in favor of other elements.
+  */
   semigroup = a: {
     append = x: y:
-      if x == nothing
+      if x.value == null
       then y
-      else if y == nothing
+      else if y.value == null
            then x
            else { value = a.append x.value y.value; };
   };
 
+  /* `optional.monoid` recovers a monoid from a semigroup by adding
+     `optional.nothing` as the empty element.
+  */
   monoid = a: semigroup a // {
     empty = { value = null; };
   };

--- a/semigroup.nix
+++ b/semigroup.nix
@@ -5,6 +5,8 @@ with rec {
   imports = {
     list = import ./list.nix;
     string = import ./string.nix;
+    nullable = import ./nullable.nix;
+    optional = import ./optional.nix;
   };
 };
 
@@ -51,25 +53,7 @@ with rec {
 
   string = imports.string.semigroup;
 
-  /* 'optional' recovers a monoid from a semigroup by adding `optional.nothing`
-     as the empty element. The semigroup's append will simply discard nothings
-     in favor of other elements.
-  */
-  optional = semigroup: {
-    append = x: y:
-      if x.value == null
-        then y
-      else if y.value == null
-        then x
-      else { value = semigroup.append x.value y.value; };
-  };
+  nullable = imports.nullable.semigroup;
 
-  nullable = semigroup: {
-    append = x: y:
-      if x == null
-        then y
-      else if y == null
-        then x
-      else semigroup.append x y;
-  };
+  optional = imports.optional.semigroup;
 }


### PR DESCRIPTION
`monad.nix` used to export `nullable.monad`, which doesn't exist for obvious reasons. This has been removed.

`optional.nix` defined `semigroup`/`monoid` that were also defined in the corresponding files, but `nullable`'s instances were only in `semigroup`/`monoid`. This moves the instances to the implementing files and re-exports the instances in `semigroup.nix`/`monoid.nix`.