### PR TITLE
Add nonempty lists

### DIFF
--- a/applicative.nix
+++ b/applicative.nix
@@ -1,11 +1,13 @@
 with {
   list = import ./list.nix;
+  nonempty = import ./nonempty.nix;
   nullable = import ./nullable.nix;
   optional = import ./optional.nix;
 };
 
 {
   list = list.applicative;
+  nonempty = nonempty.applicative;
   nullable = nullable.applicative;
   optional = optional.applicative;
 }

--- a/default.nix
+++ b/default.nix
@@ -19,6 +19,8 @@ rec {
 
   monoid = import ./monoid.nix;
 
+  nonempty = import ./nonempty.nix;
+
   nullable = import ./nullable.nix;
 
   num = import ./num.nix;

--- a/functor.nix
+++ b/functor.nix
@@ -1,11 +1,13 @@
 with {
   list = import ./list.nix;
+  nonempty = import ./nonempty.nix;
   nullable = import ./nullable.nix;
   optional = import ./optional.nix;
 };
 
 {
   list = list.functor;
+  nonempty = nonempty.functor;
   nullable = nullable.functor;
   optional = optional.functor;
 }

--- a/list.nix
+++ b/list.nix
@@ -155,7 +155,7 @@ rec {
      > list.drop 30 [ 1 2 3 4 5 ]
      []
   */
-  drop = n: slice (max 0 n) (-1);
+  drop = n: slice (max 0 n) null;
 
   /* takeEnd :: int -> [a] -> [a]
 
@@ -534,13 +534,14 @@ rec {
   */
   replicate = n: x: generate (const x) n;
 
-  /* slice :: int -> int -> [a] -> [a]
+  /* slice :: int -> nullable int -> [a] -> [a]
 
      Extract a sublist from a list given a starting position and a length. If
      the starting position is past the end of the list, return the empty list.
      If there are fewer than the requested number of elements after the starting
-     position, take as many as possible. If the requested length is negative,
-     ignore the length and return until the end of the list.
+     position, take as many as possible. If the requested length is null,
+     ignore the length and return until the end of the list. If the requested
+     length is less than 0, the length used will be 0.
 
      Fails if the given offset is negative.
 
@@ -548,16 +549,16 @@ rec {
      [ 3 4 ]
      > list.slice 2 30 [ 1 2 3 4 5 ]
      [ 3 4 5 ]
-     > list.slice 1 (-1) [ 1 2 3 4 5 ]
+     > list.slice 1 null [ 1 2 3 4 5 ]
      [ 2 3 4 5 ]
   */
   slice = offset: len: xs:
-    if offset < 0
-    then throw "std.list.slice: negative start position"
+    if offset < 0 then
+      throw "std.list.slice: negative start position"
     else
       let
         remaining = max 0 (length xs - offset);
-        len' = if len < 0 then remaining else min len remaining;
+        len' = if len == null then remaining else min (max len 0) remaining;
       in generate (i: index xs (i + offset)) len';
 
   /* range :: int -> int -> [int]

--- a/list.nix
+++ b/list.nix
@@ -243,15 +243,41 @@ rec {
   */
   modifyAt = i: f: imap (j: x: if j == i then f x else x);
 
-  /* insertAt :: int -> a -> [a] -> [a]
+  /* setAt :: int -> a -> [a] -> [a]
 
      Insert an element as the nth element of a list, returning the new list. If
      the index is out of bounds, return the list unchanged.
 
-     > list.insertAt 1 20 [ 1 2 3 ]
+     > list.setAt 1 20 [ 1 2 3 ]
      [ 1 20 3 ]
   */
-  insertAt = i: x: modifyAt i (const x);
+  setAt = i: x: modifyAt i (const x);
+
+  /* insertAt :: int -> a -> [a] -> [a]
+
+     Insert an element as the nth element of a list, returning the new list. If
+     the index is out of bounds, fail with an exception.
+
+     > list.insertAt 1 20 [ 1 2 3 ]
+     [ 1 20 2 3 ]
+     > list.insertAt 3 20 [ 1 2 3 ]
+     [ 1 2 3 20 ]
+  */
+  insertAt = i: x: xs:
+    let
+      len = length xs;
+    in if i < 0 || i > len
+      then builtins.throw "std.list.insertAt: index out of bounds"
+      else generate
+        (j:
+          if j == i then
+            x
+          else if j < i then
+            index xs j
+          else
+            index xs (j - 1)
+        )
+        (len + 1);
 
   /* ifor :: [a] -> (int -> a -> b) -> [b]
 
@@ -457,6 +483,14 @@ rec {
      false
   */
   all = builtins.all;
+
+  /* none :: (a -> bool) -> [a] -> bool
+
+     Check that none of the elements in a list match the given predicate. Note
+     that if a list is empty, none of the elements match the predicate
+     vacuously.
+  */
+  none = p: xs: builtins.all (x: !p x) xs;
 
   /* count :: (a -> bool) -> [a] -> int
 

--- a/list.nix
+++ b/list.nix
@@ -122,7 +122,7 @@ rec {
   init = xs: slice 0 (length xs - 1) xs;
 
   /* @partial
-     last :: [a] -> [a]
+     last :: [a] -> a
 
      Get the last element of a list. Fails if the list is empty.
 
@@ -135,7 +135,7 @@ rec {
 
   /* take :: int -> [a] -> [a]
 
-     Take the first n elements of a list. If there are less than n elements,
+     Take the first n elements of a list. If there are fewer than n elements,
      return as many elements as possible.
 
      > list.take 3 [ 1 2 3 4 5 ]
@@ -147,7 +147,7 @@ rec {
 
   /* drop :: int -> [a] -> [a]
 
-     Return the list minus the first n elements. If there are less than n
+     Return the list minus the first n elements. If there are fewer than n
      elements, return the empty list.
 
      > list.drop 3 [ 1 2 3 4 5 ]
@@ -159,7 +159,7 @@ rec {
 
   /* takeEnd :: int -> [a] -> [a]
 
-     Take the last n elements of a list. If there are less than n elements,
+     Take the last n elements of a list. If there are fewer than n elements,
      return as many elements as possible.
 
      > list.takeEnd 3 [ 1 2 3 4 5 ]
@@ -175,7 +175,7 @@ rec {
 
   /* dropEnd :: int -> [a] -> [a]
 
-     Return the list minus the last n elements. If there are less than n
+     Return the list minus the last n elements. If there are fewer than n
      elements, return the empty list.
 
      > list.dropEnd 3 [ 1 2 3 4 5 ]
@@ -347,7 +347,7 @@ rec {
   */
   cons = x: xs: [x] ++ xs;
 
-  /* uncons :: [a] -> (Optional a, [a])
+  /* uncons :: [a] -> (optional a, [a])
 
      Split a list into its head and tail.
   */
@@ -504,7 +504,7 @@ rec {
 
      Extract a sublist from a list given a starting position and a length. If
      the starting position is past the end of the list, return the empty list.
-     If there are less than the requested number of elements after the starting
+     If there are fewer than the requested number of elements after the starting
      position, take as many as possible. If the requested length is negative,
      ignore the length and return until the end of the list.
 
@@ -597,7 +597,7 @@ rec {
     let len = length xs;
     in generate (n: index xs (len - n - 1)) len;
 
-  /* unfold :: (b -> Optional (a, b)) -> b -> [a]
+  /* unfold :: (b -> optional (a, b)) -> b -> [a]
 
      Build a list by repeatedly applying a function to a starting value. On each
      step, the function should produce a tuple of the next value to add to the
@@ -615,10 +615,10 @@ rec {
         else go (xs ++ [(next.value._0)]) (f next.value._1);
     in go [] (f x0);
 
-  /* findIndex :: (a -> bool) -> [a] -> Optional int
+  /* findIndex :: (a -> bool) -> [a] -> optional int
 
-     Find the index of the first element matching the predicate, or null if no
-     element matches the predicate.
+     Find the index of the first element matching the predicate, or
+     `optional.nothing` if no element matches the predicate.
 
      > list.findIndex num.even [ 1 2 3 4 ]
      { value = 1; }
@@ -636,10 +636,10 @@ rec {
         else go (i + 1);
     in go 0;
 
-  /* findLastIndex :: (a -> bool) -> [a] -> Optional int
+  /* findLastIndex :: (a -> bool) -> [a] -> optional int
 
-     Find the index of the last element matching the predicate, or null if no
-     element matches the predicate.
+     Find the index of the last element matching the predicate, or
+     `optional.nothing` if no element matches the predicate.
 
      > list.findLastIndex num.even [ 1 2 3 4 ]
      { value = 3; }
@@ -657,10 +657,10 @@ rec {
         else go (i - 1);
     in go (len - 1);
 
-  /* find :: (a -> bool) -> [a] -> Optional a
+  /* find :: (a -> bool) -> [a] -> optional a
 
-     Find the first element matching the predicate, or null if no element
-     matches the predicate.
+     Find the first element matching the predicate, or `optional.nothing` if no
+     element matches the predicate.
 
      > list.find num.even [ 1 2 3 4 ]
      { value = 2; }
@@ -673,10 +673,10 @@ rec {
        then { value = null; }
        else { value = index xs i; };
 
-  /* findLast :: (a -> bool) -> [a] -> Optional a
+  /* findLast :: (a -> bool) -> [a] -> optional a
 
-     Find the last element matching the predicate, or null if no element matches
-     the predicate.
+     Find the last element matching the predicate, or `optional.nothing` if no
+     element matches the predicate.
 
      > list.find num.even [ 1 2 3 4 ]
      { value = 4; }

--- a/list.nix
+++ b/list.nix
@@ -557,6 +557,13 @@ rec {
   */
   traverse = ap: f: foldr (x: ap.lift2 cons (f x)) (ap.pure nil);
 
+  /* sequence :: Applicative f => [f a] -> f [a]
+
+     Use the provided applicative functor to sequence every element of a list of
+     applicatives.
+  */
+  sequence = ap: foldr (x: ap.lift2 cons x) (ap.pure nil);
+
   /* zipWith :: (a -> b -> c) -> [a] -> [b] -> [c]
 
      Zip two lists together with the provided function. The resulting list has

--- a/monad.nix
+++ b/monad.nix
@@ -1,9 +1,11 @@
 with {
   list = import ./list.nix;
+  nonempty = import ./nonempty.nix;
   optional = import ./optional.nix;
 };
 
 {
   list = list.monad;
+  nonempty = nonempty.monad;
   optional = optional.monad;
 }

--- a/nonempty.nix
+++ b/nonempty.nix
@@ -37,19 +37,20 @@ rec {
   monad = applicative // {
     /* join :: nonempty (nonempty a) -> nonempty a
     */
-    join = builtins.throw "TODO";
+    join = foldl' semigroup.append;
 
     /* bind :: nonempty a -> (a -> nonempty b) -> nonempty b
     */
-    bind = builtins.throw "TODO";
+    bind = { head, tail }: k:
+      let r = (k head);
+      in make r.head (r.tail ++ toList (bind tail f));
   };
 
   monadFix = monad // {
     /* fix :: (a -> nonempty a) -> nonempty a
     */
     fix = f: match (fix (compose f head)) {
-      nil = nil;
-      cons = x: _: cons x (fix (compose tail f));
+      cons = x: _: make x (fix (compose tail f));
     };
   };
 
@@ -58,7 +59,10 @@ rec {
   semigroup = {
     /* append :: nonempty a -> nonempty a -> nonempty a
     */
-    append = xs: ys: xs ++ ys;
+    append = xs: ys: {
+      head = xs.head;
+      tail = xs.tail ++ [ys.head] ++ ys.tail;
+    };
   };
 
   /* make :: a -> [a] -> nonempty a

--- a/nonempty.nix
+++ b/nonempty.nix
@@ -9,6 +9,8 @@ with rec {
   optional = import ./optional.nix;
 };
 
+/* type nonempty a = { head :: a, tail :: [a] }
+*/
 rec {
   /* List functor object
   */

--- a/nonempty.nix
+++ b/nonempty.nix
@@ -1,0 +1,336 @@
+with rec {
+  function = import ./function.nix;
+  inherit (function) const flip compose id;
+
+  num = import ./num.nix;
+  inherit (num) min max;
+
+  list = import ./list.nix;
+  optional = import ./optional.nix;
+};
+
+rec {
+  /* List functor object
+  */
+  functor = {
+    /* map :: (a -> b) -> nonempty a -> nonempty b
+    */
+    inherit map;
+  };
+
+  /* List applicative object
+  */
+  applicative = functor // rec {
+    /* pure :: a -> nonempty a
+    */
+    pure = singleton;
+    /* ap :: nonempty a -> b -> nonempty a -> nonempty b
+    */
+    ap = lift2 id;
+    /* lift2 :: (a -> b -> c) -> nonempty a -> nonempty b -> nonempty c
+    */
+    lift2 = f: xs: ys: monad.bind xs (x: monad.bind ys (y: singleton (f x y)));
+  };
+
+  /* List monad object
+  */
+  monad = applicative // {
+    /* join :: nonempty (nonempty a) -> nonempty a
+    */
+    join = concat;
+
+    /* bind :: nonempty a -> (a -> nonempty b) -> nonempty b
+    */
+    bind = flip concatMap;
+  };
+
+  monadFix = monad // {
+    /* fix :: (a -> nonempty a) -> nonempty a
+    */
+    fix = f: match (fix (compose f head)) {
+      nil = nil;
+      cons = x: _: cons x (fix (compose tail f));
+    };
+  };
+
+  /* Nonempty list semigroup object
+  */
+  semigroup = {
+    /* append :: nonempty a -> nonempty a -> nonempty a
+    */
+    append = xs: ys: xs ++ ys;
+  };
+
+  fromList = xs:
+    if builtins.length xs == 0
+    then builtins.throw "std.nonempty.fromList: empty list"
+    else { head = list.head xs; tail = list.tail xs; };
+
+  toList = { head, tail }: [head] ++ tail;
+
+  nonEmpty = xs:
+    if builtins.length xs == 0
+    then optional.nothing
+    else optional.just (fromList xs);
+
+  /* match :: nonempty a -> { cons :: a -> [a] -> b; } -> b
+
+     Pattern match on a nonempty list. As the list is never empty, 'cons' is run
+     on the head and tail of the list.
+  */
+  match = xs: { cons }@args: args.cons xs.head xs.tail;
+
+  /* head :: nonempty a -> a
+
+     Get the first element of a nonempty list.
+  */
+  head = builtins.head;
+
+  /* tail :: nonempty a -> [a]
+
+     Return the list minus the first element, which may be an empty list.
+  */
+  tail = builtins.tail;
+
+  /* init :: nonempty a -> [a]
+
+     Return the list minus the last element, which may be an empty list.
+  */
+  init = { head, tail }:
+    if builtins.length tail == 0
+    then [head]
+    else [head] ++ list.init tail;
+
+  /* last :: [a] -> a
+
+     Get the last element of a nonempty list.
+  */
+  last = { head, tail }:
+    if builtins.length tail == 0
+    then head
+    else list.last tail;
+
+  /* take :: int -> nonempty a -> [a]
+
+     Take the first n elements of a list. If there are less than n elements,
+     return as many elements as possible.
+  */
+  take = builtins.throw "TODO";
+
+  /* drop :: int -> nonempty a -> [a]
+
+     Return the list minus the first n elements. If there are less than n
+     elements, return the empty list.
+  */
+  drop = builtins.throw "TODO";
+
+  /* takeEnd :: int -> nonempty a -> [a]
+
+     Take the last n elements of a list. If there are less than n elements,
+     return as many elements as possible.
+  */
+  takeEnd = builtins.throw "TODO";
+
+  /* dropEnd :: int -> nonempty a -> [a]
+
+     Return the list minus the last n elements. If there are less than n
+     elements, return the empty list.
+  */
+  dropEnd = builtins.throw "TODO";
+
+  /* length :: nonempty a -> int
+
+     Return the length of a nonempty list.
+  */
+  length = { head, tail }: builtins.length tail + 1;
+
+  /* singleton :: a -> nonempty a
+
+     Wrap an element in a singleton list.
+  */
+  singleton = head: { inherit head; tail = []; };
+
+  /* map :: (a -> b) -> nonempty a -> nonempty b
+
+     Apply a function to every element of a nonempty list, returning the
+     resulting list.
+  */
+  map = builtins.throw "TODO";
+
+  /* for :: nonempty a -> (a -> b) -> nonempty b
+
+     Like 'map', but with its arguments reversed.
+  */
+  for = flip map;
+
+  /* imap :: (int -> a -> b) -> nonempty a -> nonempty b
+
+     Apply a function to every element of a list and its index, returning the
+     resulting list.
+  */
+  imap = builtins.throw "TODO";
+
+  /* modifyAt :: int -> (a -> a) -> nonempty a -> nonempty a
+
+     Apply a function to the nth element of a list, returning the new list. If
+     the index is out of bounds, return the list unchanged.
+  */
+  modifyAt = builtins.throw "TODO";
+
+  /* insertAt :: int -> a -> nonempty a -> nonempty a
+
+     Insert an element as the nth element of a list, returning the new list. If
+     the index is out of bounds, return the list unchanged.
+  */
+  insertAt = builtins.throw "TODO";
+
+  /* ifor :: nonempty a -> (int -> a -> b) -> nonempty b
+
+     Like 'imap', but with its arguments reversed.
+  */
+  ifor = flip imap;
+
+  /* @partial
+     elemAt :: nonempty a -> int -> a
+
+     Get the nth element of a list, indexed from 0.
+  */
+  elemAt = builtins.elemAt;
+
+  /* @partial
+     index :: nonempty a -> int -> a
+
+     Get the nth element of a list, indexed from 0. An alias for 'elemAt'.
+  */
+  index = builtins.elemAt;
+
+  /* filter :: (a -> bool) -> nonempty a -> [a]
+
+     Apply a predicate to a list, keeping only the elements that match the
+     predicate.
+  */
+  filter = builtins.throw "TODO";
+
+  /* elem :: a -> nonempty a -> bool
+
+     Check if an element is contained in a list.
+  */
+  elem = builtins.throw "TODO";
+
+  /* notElem :: a -> nonempty a -> bool
+
+     Check if an element is not contained in a list.
+  */
+  notElem = builtins.throw "TODO";
+
+  /* cons :: a -> nonempty a -> nonempty a
+
+     Prepend an element to a nonempty list
+  */
+  cons = x: xs: { head = x; tail = [xs.head] ++ xs.tail; };
+
+  /* uncons :: nonempty a -> (a, [a])
+
+     Split a nonempty list into its head and tail.
+  */
+  uncons = { head, tail }: { _0 = head; _1 = tail; };
+
+  /* snoc :: nonempty a -> a -> nonempty a
+
+     Append an element to a nonempty list
+  */
+  snoc = xs: x: { head = xs.head; tail = xs.tail ++ [x]; };
+
+  /* foldr :: (a -> b -> b) -> [a] -> b
+
+     Right-associative fold over a nonempty list.
+  */
+  foldr = builtins.throw "TODO";
+
+  /* foldl' :: (b -> a -> b) -> [a] -> b
+
+     Strict left-associative fold over a nonempty list.
+  */
+  foldl' = builtins.throw "TODO";
+
+  /* foldMap :: Semigroup m => (a -> m) -> nonempty a -> m
+
+     Apply a function to each element of a list, turning it into a semigroup,
+     and append all the results using the provided semigroup.
+  */
+  foldMap = builtins.throw "TODO";
+
+  /* fold :: Semigroup m => nonempty m -> m
+
+     Append all elements of a list using a provided semigroup.
+  */
+  fold = builtins.throw "TODO";
+
+  /* sum :: nonempty number -> number
+
+     Sum a nonempty list of numbers.
+  */
+  sum = foldl' builtins.add;
+
+  /* product :: [number] -> number
+
+     Take the product of a list of numbers.
+
+     > list.product [ 1 2 3 4 ]
+     24
+  */
+  product = foldl' builtins.mul;
+
+  /* any :: (a -> bool) -> nonempty a -> bool
+
+     Check if any element of a list matches a predicate.
+  */
+  any = builtins.throw "TODO";
+
+  /* all :: (a -> bool) -> nonempty a -> bool
+
+     Check if every element of a list matches a predicate. Note that if a list
+     is empty, the predicate matches every element vacuously.
+  */
+  all = builtins.throw "TODO";
+
+  /* count :: (a -> bool) -> nonempty a -> int
+
+     Count the number of times a predicate holds on the elements of a list.
+  */
+  count = builtins.throw "TODO";
+
+  /* sequence :: Ap f => nonempty (f a) -> f (nonempty a)
+
+     Sequence a nonempty list using the provided applicative functor.
+  */
+  traverse = builtins.throw "TODO";
+
+
+  /* traverse :: Ap f => (a -> f b) -> nonempty a -> f (nonempty b)
+
+     Apply a function to every element of a list, and sequence the results using
+     the provided applicative functor.
+  */
+  traverse = builtins.throw "TODO";
+
+  /* zipWith :: (a -> b -> c) -> nonempty a -> nonempty b -> nonempty c
+
+     Zip two lists together with the provided function. The resulting list has
+     length equal to the length of the shorter list.
+  */
+  zipWith = builtins.throw "TODO";
+
+  /* zip :: nonempty a -> nonempty b -> nonempty (a, b)
+
+     Zip two lists together into a list of tuples. The resulting list has length
+     equal to the length of the shorter list.
+  */
+  zip = zipWith (x: y: { _0 = x; _1 = y; });
+
+  /* reverse :: nonempty a -> nonempty a
+
+     Reverse a nonempty list.
+  */
+  reverse = builtins.throw "TODO";
+}

--- a/nonempty.nix
+++ b/nonempty.nix
@@ -34,7 +34,7 @@ rec {
 
   /* List monad object
   */
-  monad = applicative // {
+  monad = applicative // rec {
     /* join :: nonempty (nonempty a) -> nonempty a
     */
     join = foldl' semigroup.append;
@@ -42,8 +42,8 @@ rec {
     /* bind :: nonempty a -> (a -> nonempty b) -> nonempty b
     */
     bind = { head, tail }: k:
-      let r = (k head);
-      in make r.head (r.tail ++ toList (bind tail f));
+      let r = k head;
+      in make r.head (r.tail ++ list.monad.bind tail (x: toList (k x)));
   };
 
   monadFix = monad // {
@@ -152,7 +152,7 @@ rec {
     else
       let
         remaining = max 0 (builtins.length tail + 1 - offset);
-        len' = if len < 0 then remaining else min len remaining;
+        len' = if len == null then remaining else min (max len 0) remaining;
       in list.generate
         (i:
           let i' = i + offset;
@@ -389,7 +389,7 @@ rec {
 
      Count the number of times a predicate holds on the elements of a list.
   */
-  count = p: { head, tail }: (if p head then 0 else 1) + list.count p tail;
+  count = p: { head, tail }: (if p head then 1 else 0) + list.count p tail;
 
   /* traverse :: Apply f => (a -> f b) -> nonempty a -> f (nonempty b)
 

--- a/nonempty.nix
+++ b/nonempty.nix
@@ -363,18 +363,30 @@ rec {
      the provided applicative functor.
   */
   traverse = ap: f: { head, tail }:
-    # TODO: turn applicative constraint here into apply constraint, remove
-    # list.traverse
-    ap.lift2 make (f head) (list.traverse ap f tail);
+    let
+      tailLen = builtins.length tail;
+      go = n:
+        if n == tailLen - 1
+        then ap.map list.singleton (f (list.index tail n))
+        else ap.lift2 list.cons (f (list.index tail n)) (go (n + 1));
+    in if tailLen == 0
+      then ap.map (x: make x []) (f head)
+      else ap.lift2 make (f head) (go 0);
 
   /* sequence :: Apply f => nonempty (f a) -> f (nonempty a)
 
      Sequence a nonempty list using the provided applicative functor.
   */
   sequence = ap: { head, tail }:
-    # TODO: turn applicative constraint here into apply constraint, remove
-    # list.sequence
-    ap.fmap (make head) (list.sequence ap tail);
+    let
+      tailLen = builtins.length tail;
+      go = n:
+        if n == tailLen - 1
+        then ap.map list.singleton (list.index tail n)
+        else ap.lift2 list.cons (list.index tail n) (go (n + 1));
+    in if tailLen == 0
+      then ap.map (x: make x []) (f head)
+      else ap.lift2 make head (go 0);
 
   /* zipWith :: (a -> b -> c) -> nonempty a -> nonempty b -> nonempty c
 

--- a/semigroup.nix
+++ b/semigroup.nix
@@ -7,6 +7,7 @@ with rec {
     string = import ./string.nix;
     nullable = import ./nullable.nix;
     optional = import ./optional.nix;
+    nonempty = import ./nonempty.nix;
   };
 };
 
@@ -52,6 +53,8 @@ with rec {
   list = imports.list.semigroup;
 
   string = imports.string.semigroup;
+
+  nonempty = imports.nonempty.semigroup;
 
   nullable = imports.nullable.semigroup;
 

--- a/test.nix
+++ b/test.nix
@@ -676,6 +676,10 @@ let
         (assertEqual true (list.all (const true) []))
         (assertEqual true (list.all (const false) []))
       ];
+      none = string.unlines [
+        (assertEqual true (list.none num.odd (list.generate (i: builtins.mul i 2) 10)))
+        (assertEqual false (list.none num.odd [2 4 5 8]))
+      ];
       count = assertEqual 11 (list.count num.even (list.generate id 21));
       optional = string.unlines [
         (assertEqual [] (list.optional false null))
@@ -920,6 +924,10 @@ let
       all = string.unlines [
         (assertEqual true (nonempty.all num.even (nonempty.unsafeFromList (list.generate (i: builtins.mul i 2) 10))))
         (assertEqual false (nonempty.all num.even (nonempty.make 2 [4 5 8])))
+      ];
+      none = string.unlines [
+        (assertEqual true (nonempty.none num.odd (nonempty.unsafeFromList (list.generate (i: builtins.mul i 2) 10))))
+        (assertEqual false (nonempty.none num.odd (nonempty.make 2 [4 5 8])))
       ];
       count = assertEqual 11 (nonempty.count num.even (nonempty.unsafeFromList (list.generate id 21)));
       slice = string.unlines [

--- a/test.nix
+++ b/test.nix
@@ -689,7 +689,7 @@ let
       slice = string.unlines [
         (assertEqual [3 4] (list.slice 2 2 [ 1 2 3 4 5 ]))
         (assertEqual [3 4 5] (list.slice 2 30 [ 1 2 3 4 5 ]))
-        (assertEqual [2 3 4 5] (list.slice 1 (-1) [ 1 2 3 4 5 ]))
+        (assertEqual [2 3 4 5] (list.slice 1 null [ 1 2 3 4 5 ]))
       ];
       range = assertEqual [1 2 3 4 5] (list.range 1 5);
       partition = string.unlines [

--- a/test.nix
+++ b/test.nix
@@ -624,10 +624,14 @@ let
         (assertEqual [ 1 20 3 ] (list.modifyAt 1 (x: 10 * x) [ 1 2 3 ]))
         (assertEqual [ 1 2 3 ] (list.modifyAt (-3) (x: 10 * x) [ 1 2 3 ]))
       ];
-
+      setAt = string.unlines [
+        (assertEqual [ 1 20 3 ] (list.setAt 1 20 [ 1 2 3 ]))
+        (assertEqual [ 1 2 3 ] (list.setAt (-3) 20 [ 1 2 3 ]))
+      ];
       insertAt = string.unlines [
-        (assertEqual [ 1 20 3 ] (list.insertAt 1 20 [ 1 2 3 ]))
-        (assertEqual [ 1 2 3 ] (list.insertAt (-3) 20 [ 1 2 3 ]))
+        (assertEqual [ 1 20 2 3 ] (list.insertAt 1 20 [ 1 2 3 ]))
+        (assertEqual [ 20 1 2 3 ] (list.insertAt 0 20 [ 1 2 3 ]))
+        (assertEqual [ 1 2 3 20 ] (list.insertAt 3 20 [ 1 2 3 ]))
       ];
       ifor = assertEqual ["foo-0" "bar-1"] (list.ifor ["foo" "bar"] (i: s: s + "-" + builtins.toString i));
       elemAt = assertEqual "barry" (list.elemAt ["bar" "ry" "barry"] 2);

--- a/test.nix
+++ b/test.nix
@@ -702,6 +702,10 @@ let
       zip = assertEqual
         [{ _0 = "foo"; _1 = 0; } { _0 = "foo"; _1 = 1; } { _0 = "foo"; _1 = 2; }]
         (list.zip (list.replicate 10 "foo") (list.range 0 2));
+      sequence = string.unlines [
+        (let ls = list.range 1 10; in assertEqual ls (list.sequence nullable.applicative ls))
+        (let ls = list.range 1 10; in assertEqual null (list.sequence nullable.applicative (ls ++ [null])))
+      ];
       traverse = string.unlines [
         (let ls = list.range 1 10; in assertEqual ls (list.traverse nullable.applicative (x: if (num.even x || num.odd x) then x else null) ls))
       ];
@@ -748,6 +752,237 @@ let
 
       break = assertEqual { _0 = [ 2 4 6 ]; _1 = [ 9 10 11 12 14 ]; }
         (list.break num.odd [ 2 4 6 9 10 11 12 14 ]);
+    };
+
+    nonempty = section "std.nonempty" {
+      laws = string.unlines [
+        (functor nonempty.functor {
+          typeName = "nonempty";
+          identity = {
+            x = nonempty.unsafeFromList [1 2 3 4 5];
+          };
+          composition = {
+            f = x: nonempty.semigroup.append x x;
+            g = nonempty.singleton;
+            x = nonempty.unsafeFromList [1 2 3 4 5];
+          };
+        })
+        (applicative nonempty.applicative {
+          typeName = "nonempty";
+          identity = {
+            v = nonempty.unsafeFromList [1 2 3 4];
+          };
+          composition = {
+            u = nonempty.unsafeFromList [
+              (b: builtins.toString (b + 1))
+              (b: builtins.toString (b * 2))
+              (b: builtins.toString (5 * (b + 1)))
+            ];
+            v = nonempty.unsafeFromList [
+              (a: a + 1)
+              (a: a * 2)
+              (b: 5 * (b + 1))
+            ];
+            w = nonempty.unsafeFromList [ 1 2 3 4 5 ];
+          };
+          homomorphism = {
+            f = builtins.toString;
+            x = 5;
+          };
+          interchange = {
+            u = nonempty.ifor
+                  (nonempty.unsafeFromList ["foo" "bar" "baz"])
+                  (i: s: (u: builtins.toString u + "-" + s + "-" + builtins.toString i));
+            y = 20.0;
+          };
+        })
+        (monad nonempty.monad {
+          typeName = "nonempty";
+          leftIdentity = {
+            f = x: nonempty.make x [x x];
+            x = 10;
+          };
+          rightIdentity = {
+            x = nonempty.unsafeFromList (list.range 1 10);
+          };
+          associativity = {
+            m = nonempty.unsafeFromList [1 2 3 4 5];
+            f = x: nonempty.singleton (x + 1);
+            g = x: nonempty.unsafeFromList (list.range x (x + 1));
+          };
+        })
+        (semigroup nonempty.semigroup {
+          typeName = "nonempty";
+          associativity = {
+            a = nonempty.unsafeFromList [1 2];
+            b = nonempty.unsafeFromList ["foo" "bar"];
+            c = nonempty.unsafeFromList [true false];
+          };
+        })
+      ];
+
+      match =
+        let ls = nonempty.unsafeFromList ["foo" "baz" "bow" "bar" "bed"];
+            go = xs0: nonempty.match xs0 {
+              cons = _: xs: builtins.head xs;
+            };
+        in assertEqual "baz" (go ls);
+
+      fromList = string.unlines [
+        (assertEqual optional.nothing (nonempty.fromList []))
+        (assertEqual (optional.just (nonempty.singleton 1)) (nonempty.fromList [1]))
+        (assertEqual (optional.just (nonempty.make 1 [2])) (nonempty.fromList [1 2]))
+      ];
+
+      unsafeFromList = string.unlines [
+        (assertEqual false ((builtins.tryEval (nonempty.unsafeFromList [])).success))
+        (assertEqual (nonempty.singleton 1) (nonempty.unsafeFromList [1]))
+        (assertEqual (nonempty.make 1 [2]) (nonempty.unsafeFromList [1 2]))
+      ];
+
+      toList = string.unlines [
+        (assertEqual [1] (nonempty.toList (nonempty.singleton 1)))
+        (assertEqual [1 2] (nonempty.toList (nonempty.make 1 [2])))
+      ];
+
+      head = assertEqual 10 (nonempty.head (nonempty.make 10 [20 30]));
+      tail = assertEqual [20 30] (nonempty.tail (nonempty.make 10 [20 30]));
+      init = assertEqual [10 20] (nonempty.init (nonempty.make 10 [20 30]));
+      last = assertEqual 30 (nonempty.last (nonempty.make 10 [20 30]));
+
+      take = let xs = nonempty.unsafeFromList (list.range 1 20); in string.unlines [
+        (assertEqual [1 2 3 4] (nonempty.take 4 xs))
+        (assertEqual (nonempty.toList xs) (nonempty.take 100 xs))
+      ];
+
+      drop = let xs = nonempty.unsafeFromList (list.range 1 20); in string.unlines [
+        (assertEqual (list.range 5 20) (nonempty.drop 4 xs))
+        (assertEqual [] (nonempty.drop 100 xs))
+        (assertEqual (nonempty.toList xs) (nonempty.drop (-1) xs))
+      ];
+
+      takeEnd = let xs = nonempty.unsafeFromList (list.range 1 20); in string.unlines [
+        (assertEqual [17 18 19 20] (nonempty.takeEnd 4 xs))
+        (assertEqual (nonempty.toList xs) (nonempty.takeEnd 100 xs))
+        (assertEqual [] (nonempty.takeEnd (-1) xs))
+      ];
+
+      dropEnd = let xs = nonempty.unsafeFromList (list.range 1 20); in string.unlines [
+        (assertEqual (list.range 1 16) (nonempty.dropEnd 4 xs))
+        (assertEqual [] (nonempty.dropEnd 100 xs))
+        (assertEqual (nonempty.toList xs) (nonempty.dropEnd (-1) xs))
+      ];
+
+      length = assertEqual 20 (nonempty.length (nonempty.unsafeFromList (list.range 1 20)));
+      singleton = assertEqual (nonempty.make 10 []) (nonempty.singleton 10);
+      map = assertEqual (nonempty.make "foo-0" [ "foo-1" ]) (nonempty.map (i: "foo-" + builtins.toString i) (nonempty.make 0 [ 1 ]));
+      for = assertEqual (nonempty.make "foo-0" [ "foo-1" ]) (nonempty.for (nonempty.make 0 [1]) (i: "foo-" + builtins.toString i));
+      imap = assertEqual (nonempty.make "foo-0" [ "bar-1" ]) (nonempty.imap (i: s: s + "-" + builtins.toString i) (nonempty.make "foo" [ "bar" ]));
+      ifor = assertEqual (nonempty.make "foo-0" [ "bar-1" ]) (nonempty.ifor (nonempty.make "foo" [ "bar" ]) (i: s: s + "-" + builtins.toString i));
+      modifyAt = string.unlines [
+        (assertEqual (nonempty.make 1 [ 20 3 ]) (nonempty.modifyAt 1 (x: 10 * x) (nonempty.make 1 [ 2 3 ])))
+        (assertEqual (nonempty.make 1 [ 2 3 ]) (nonempty.modifyAt (-3) (x: 10 * x) (nonempty.make 1 [ 2 3 ])))
+      ];
+      setAt = string.unlines [
+        (assertEqual (nonempty.make 1 [ 20 3 ]) (nonempty.setAt 1 20 (nonempty.make 1 [ 2 3 ])))
+        (assertEqual (nonempty.make 1 [ 2 3 ]) (nonempty.setAt (-3) 20 (nonempty.make 1 [ 2 3 ])))
+      ];
+      insertAt = string.unlines [
+        (assertEqual (nonempty.make 1 [ 20 2 3 ]) (nonempty.insertAt 1 20 (nonempty.make 1 [ 2 3 ])))
+        (assertEqual (nonempty.make 20 [ 1 2 3 ]) (nonempty.insertAt 0 20 (nonempty.make 1 [ 2 3 ])))
+        (assertEqual (nonempty.make 1 [ 2 3 20 ]) (nonempty.insertAt 3 20 (nonempty.make 1 [ 2 3 ])))
+      ];
+      elemAt = assertEqual "barry" (nonempty.elemAt (nonempty.make "bar" ["ry" "barry"]) 2);
+      index = assertEqual "barry" (nonempty.index (nonempty.make "bar" ["ry" "barry"]) 2);
+      filter = assertEqual ["foo" "fun" "friends"] (nonempty.filter (string.hasPrefix "f") (nonempty.make "foo" ["oof" "fun" "nuf" "friends" "sdneirf"]));
+      elem = assertEqual builtins.true (nonempty.elem "friend" (nonempty.make "texas" ["friend" "amigo"]));
+      notElem = assertEqual builtins.true (nonempty.notElem "foo" (nonempty.make "texas" ["friend" "amigo"]));
+      cons = assertEqual (nonempty.make 1 [2 3 4 5]) (nonempty.cons 1 (nonempty.make 2 [3 4 5]));
+      uncons = assertEqual { _0 = 1; _1 = [2 3 4 5]; } (nonempty.uncons (nonempty.make 1 [2 3 4 5]));
+      snoc = assertEqual (nonempty.make 1 [2 3 4 5]) (nonempty.snoc (nonempty.make 1 [2 3 4]) 5);
+
+      foldr = assertEqual 55 (nonempty.foldr builtins.add (nonempty.unsafeFromList (list.range 1 10)));
+      foldl' = assertEqual 3628800 (nonempty.foldl' builtins.mul (nonempty.unsafeFromList (list.range 1 10)));
+      foldMap = string.unlines [
+        (assertEqual 1 (nonempty.foldMap std.semigroup.first id (nonempty.unsafeFromList (list.range 1 10))))
+        (assertEqual 321 ((nonempty.foldMap std.semigroup.endo id (nonempty.make (x: builtins.mul x 3) [ (x: builtins.add x 7) (x: num.pow x 2) ])) 10))
+      ];
+      fold = string.unlines [
+        (assertEqual 1 (nonempty.fold std.semigroup.first (nonempty.unsafeFromList (list.range 1 10))))
+        (assertEqual 321 ((nonempty.fold std.semigroup.endo (nonempty.make (x: builtins.mul x 3) [ (x: builtins.add x 7) (x: num.pow x 2) ])) 10))
+      ];
+      sum = assertEqual 55 (nonempty.sum (nonempty.unsafeFromList (list.range 1 10)));
+      product = assertEqual 3628800 (nonempty.product (nonempty.unsafeFromList (list.range 1 10)));
+      any = string.unlines [
+        (assertEqual true (nonempty.any num.even (nonempty.make 1 [2 3 4 5])))
+        (assertEqual false (nonempty.any num.even (nonempty.make 1 [3 5])))
+      ];
+      all = string.unlines [
+        (assertEqual true (nonempty.all num.even (nonempty.unsafeFromList (list.generate (i: builtins.mul i 2) 10))))
+        (assertEqual false (nonempty.all num.even (nonempty.make 2 [4 5 8])))
+      ];
+      count = assertEqual 11 (nonempty.count num.even (nonempty.unsafeFromList (list.generate id 21)));
+      slice = string.unlines [
+        (assertEqual [3 4] (nonempty.slice 2 2 (nonempty.make 1 [2 3 4 5])))
+        (assertEqual [3 4 5] (nonempty.slice 2 30 (nonempty.make 1 [2 3 4 5])))
+        (assertEqual [2 3 4 5] (nonempty.slice 1 null (nonempty.make 1 [2 3 4 5])))
+      ];
+      zipWith = assertEqual
+        (nonempty.make "foo-0" ["foo-1" "foo-2"])
+        (nonempty.zipWith (s: i: s + "-" + builtins.toString i) (nonempty.unsafeFromList (list.replicate 10 "foo")) (nonempty.unsafeFromList (list.range 0 2)));
+      zip = assertEqual
+        (nonempty.make { _0 = "foo"; _1 = 0; } [{ _0 = "foo"; _1 = 1; } { _0 = "foo"; _1 = 2; }])
+        (nonempty.zip (nonempty.unsafeFromList (list.replicate 10 "foo")) (nonempty.unsafeFromList (list.range 0 2)));
+      sequence = string.unlines [
+        (let ls = nonempty.unsafeFromList (list.range 1 10); in assertEqual ls (nonempty.sequence nullable.applicative ls))
+        (let ls = nonempty.unsafeFromList (list.range 1 10); in assertEqual null (nonempty.sequence nullable.applicative (nonempty.snoc ls null)))
+      ];
+      traverse = string.unlines [
+        (let ls = nonempty.unsafeFromList (list.range 1 10); in assertEqual ls (nonempty.traverse nullable.applicative (x: if (num.even x || num.odd x) then x else null) ls))
+      ];
+      reverse = string.unlines [
+        (assertEqual (nonempty.make 3 [2 1]) (nonempty.reverse (nonempty.make 1 [2 3])))
+        (assertEqual (nonempty.make 1 []) (nonempty.reverse (nonempty.make 1 [])))
+      ];
+
+      # unfold = assertEqual [10 9 8 7 6 5 4 3 2 1]
+      #   (list.unfold (n: if n == 0 then optional.nothing else optional.just { _0 = n; _1 = n - 1; }) 10);
+
+      # findIndex = string.unlines [
+      #   (assertEqual 1 (list.findIndex num.even [ 1 2 3 4 ]).value)
+      #   (assertEqual null (list.findIndex num.even [ 1 3 5 ]).value)
+      # ];
+
+      # findLastIndex = string.unlines [
+      #   (assertEqual 3 (list.findLastIndex num.even [ 1 2 3 4 ]).value)
+      #   (assertEqual null (list.findLastIndex num.even [ 1 3 5 ]).value)
+      # ];
+
+      # find = string.unlines [
+      #   (assertEqual 2 (list.find num.even [ 1 2 3 4 ]).value)
+      #   (assertEqual null (list.find num.even [ 1 3 5 ]).value)
+      # ];
+
+      # findLast = string.unlines [
+      #   (assertEqual 4 (list.findLast num.even [ 1 2 3 4 ]).value)
+      #   (assertEqual null (list.findLast num.even [ 1 3 5 ]).value)
+      # ];
+
+      # splitAt = assertEqual { _0 = [ 1 ]; _1 = [ 2 3 ]; } (list.splitAt 1 [ 1 2 3 ]);
+
+      # takeWhile = assertEqual [ 2 4 6 ] (list.takeWhile num.even [ 2 4 6 9 10 11 12 14 ]);
+
+      # dropWhile = assertEqual [ 9 10 11 12 14 ] (list.dropWhile num.even [ 2 4 6 9 10 11 12 14 ]);
+
+      # takeWhileEnd = assertEqual [ 12 14 ] (list.takeWhileEnd num.even [ 2 4 6 9 10 11 12 14 ]);
+
+      # dropWhileEnd = assertEqual [ 2 4 6 9 10 11 ] (list.dropWhileEnd num.even [ 2 4 6 9 10 11 12 14 ]);
+
+      # span = assertEqual { _0 = [ 2 4 6 ]; _1 = [ 9 10 11 12 14 ]; }
+      #   (list.span num.even [ 2 4 6 9 10 11 12 14 ]);
+
+      # break = assertEqual { _0 = [ 2 4 6 ]; _1 = [ 9 10 11 12 14 ]; }
+      #   (list.break num.odd [ 2 4 6 9 10 11 12 14 ]);
     };
 
     optional = section "std.optional" {


### PR DESCRIPTION
Adds a `nonempty` type representing nonempty lists, along with corresponding functions/instances and test coverage. Also adds a couple of extra list utilities.