### PR TITLE
Fix serde.toTOML

### DIFF
--- a/test.nix
+++ b/test.nix
@@ -716,6 +716,30 @@ let
       ];
       until = assertEqual 400 (fixpoints.until (x: num.mod x 20 == 0) (compose (builtins.add 1) (builtins.mul 7)) 1);
     };
+
+    serde = section "std.serde" {
+      toTOML =
+        let
+          checkRoundtrip = data:
+            assertEqual true (builtins.fromTOML (serde.toTOML data) == data);
+        in
+        string.unlines [
+          # basic k = v notation
+          (checkRoundtrip { foo = 1; })
+          # inline JSON-like literals
+          (checkRoundtrip { foo = [1 2 3]; })
+          # basic table
+          (checkRoundtrip { foo.bar = 1; })
+          # nested tables with dots
+          (checkRoundtrip { foo.bar.baz = 1; })
+          # properly escapes invalid identifiers
+          (checkRoundtrip { foo."bar.baz-quux".xyzzy = 1; })
+          # double-bracket list notation for lists of dictionaries
+          (checkRoundtrip { foo = [{ bar = 1; } { bar = [{ quux = 2; }]; }]; })
+          # mixing dot notation and list notation
+          (checkRoundtrip { foo.bar.baz = [{ bar = 1; } { bar = [{ quux = 2; }]; }]; })
+        ];
+    };
   };
 in
 builtins.derivation {


### PR DESCRIPTION
At some point, the naming conventions of `set.toList` changed to be tuples, so the name/value pairs in `serde.toTOML` needed to be changed to _0/_1 pairs instead.

Also adds tests to make sure basic cases roundtrip properly, and adds an extra check on the input data to make sure it's an attrset.