### PR TITLE
Fix new optional representation

### DIFF
--- a/list.nix
+++ b/list.nix
@@ -665,14 +665,14 @@ rec {
      > list.findIndex num.even [ 1 2 3 4 ]
      { _tag = "just"; value = 1; }
      > list.findIndex num.even [ 1 3 5 ]
-     { _tag = "nothing"; value = null; }
+     { _tag = "nothing"; }
   */
   findIndex = pred: xs:
     let
       len = length xs;
       go = i:
         if i >= len
-        then { _tag = "nothing"; value = null; } #_optional.nothing
+        then { _tag = "nothing"; } #_optional.nothing
         else if pred (index xs i)
              then { _tag = "just"; value = i; } #_optional.just i
              else go (i + 1);
@@ -686,7 +686,7 @@ rec {
      > list.findLastIndex num.even [ 1 2 3 4 ]
      { _tag = "just"; value = 3; }
      > list.findLastIndex num.even [ 1 3 5 ]
-     { _tag = "nothing"; value = null; }
+     { _tag = "nothing"; }
   */
   findLastIndex = pred: xs:
     let
@@ -707,7 +707,7 @@ rec {
      > list.find num.even [ 1 2 3 4 ]
      { _tag = "just"; value = 2; }
      > list.find num.even [ 1 3 5 ]
-     { _tag = "nothing"; value = null; }
+     { _tag = "nothing"; }
   */
   find = pred: xs:
     _optional.match (findIndex pred xs) {
@@ -723,7 +723,7 @@ rec {
      > list.find num.even [ 1 2 3 4 ]
      { _tag = "just"; value = 4; }
      > list.find num.even [ 1 3 5 ]
-     { _tag = "nothing"; value = null; }
+     { _tag = "nothing"; }
   */
   findLast = pred: xs:
     _optional.match (findLastIndex pred xs) {

--- a/list.nix
+++ b/list.nix
@@ -5,7 +5,7 @@ with rec {
   num = import ./num.nix;
   inherit (num) min max;
 
-  optional = import ./optional.nix;
+  _optional = import ./optional.nix;
 };
 
 rec {
@@ -80,10 +80,10 @@ rec {
   */
   match = xs: args:
     let u = uncons xs;
-    in optional.match u._0 {
-         nothing = args.nil;
-         just = v: args.cons v u._1;
-       };
+    in _optional.match u {
+      nothing = args.nil;
+      just = v: args.cons v._0 v._1;
+    };
 
   /* empty :: [a] -> bool
 
@@ -376,17 +376,16 @@ rec {
   */
   cons = x: xs: [x] ++ xs;
 
-  /* uncons :: [a] -> (optional a, [a])
+  /* uncons :: [a] -> optional (a, [a])
 
      Split a list into its head and tail.
   */
   uncons = xs: if (length xs == 0)
-    then { _0 = optional.nothing;
-           _1 = [];
-         }
-    else { _0 = optional.just (builtins.head xs);
-           _1 = builtins.tail xs;
-         };
+    then _optional.nothing
+    else _optional.just {
+      _0 = builtins.head xs;
+      _1 = builtins.tail xs;
+    };
 
   /* snoc :: [a] -> a -> [a]
 
@@ -652,7 +651,7 @@ rec {
   unfold = f: x0:
     let
       go = xs: next:
-        optional.match next {
+        _optional.match next {
           nothing = xs;
           just = v: go (xs ++ [v._0]) (f v._1);
         };
@@ -673,9 +672,9 @@ rec {
       len = length xs;
       go = i:
         if i >= len
-        then { _tag = "nothing"; value = null; } #optional.nothing
+        then { _tag = "nothing"; value = null; } #_optional.nothing
         else if pred (index xs i)
-             then { _tag = "just"; value = i; } #optional.just i
+             then { _tag = "just"; value = i; } #_optional.just i
              else go (i + 1);
     in go 0;
 
@@ -694,9 +693,9 @@ rec {
       len = length xs;
       go = i:
         if i < 0
-        then optional.nothing
+        then _optional.nothing
         else if pred (index xs i)
-             then optional.just i
+             then _optional.just i
              else go (i - 1);
     in go (len - 1);
 
@@ -711,9 +710,9 @@ rec {
      { _tag = "nothing"; value = null; }
   */
   find = pred: xs:
-    optional.match (findIndex pred xs) {
-      nothing = optional.nothing;
-      just = i: optional.just (index xs i);
+    _optional.match (findIndex pred xs) {
+      nothing = _optional.nothing;
+      just = i: _optional.just (index xs i);
     };
 
   /* findLast :: (a -> bool) -> [a] -> optional a
@@ -727,9 +726,9 @@ rec {
      { _tag = "nothing"; value = null; }
   */
   findLast = pred: xs:
-    optional.match (findLastIndex pred xs) {
-      nothing = optional.nothing;
-      just = i: optional.just (index xs i);
+    _optional.match (findLastIndex pred xs) {
+      nothing = _optional.nothing;
+      just = i: _optional.just (index xs i);
     };
 
   /* splitAt :: int -> [a] -> ([a], [a])
@@ -750,7 +749,7 @@ rec {
      [ 2 4 6 ]
   */
   takeWhile = pred: xs:
-    optional.match (findIndex (x: !pred x) xs) {
+    _optional.match (findIndex (x: !pred x) xs) {
       nothing = xs;
       just = i: take i xs;
     };
@@ -763,7 +762,7 @@ rec {
      [ 9 10 11 12 14 ]
   */
   dropWhile = pred: xs:
-    match (findIndex (x: !pred x) xs) {
+    _optional.match (findIndex (x: !pred x) xs) {
       nothing = xs;
       just = i: drop i xs;
     };
@@ -776,7 +775,7 @@ rec {
      [ 12 14 ]
   */
   takeWhileEnd = pred: xs:
-    optional.match (findLastIndex (x: !pred x) xs) {
+    _optional.match (findLastIndex (x: !pred x) xs) {
       nothing = xs;
       just = i: drop (i + 1) xs;
     };
@@ -789,7 +788,7 @@ rec {
      [ 2 4 6 9 10 11 ]
   */
   dropWhileEnd = pred: xs:
-    optional.match (findLastIndex (x: !pred x) xs) {
+    _optional.match (findLastIndex (x: !pred x) xs) {
       nothing = xs;
       just = i: take (i + 1) xs;
     };
@@ -803,7 +802,7 @@ rec {
      { _0 = [ 2 4 6 ]; _1 = [ 9 10 11 12 14 ]; }
   */
   span = pred: xs:
-    optional.match (findIndex (x: !pred x) xs) {
+    _optional.match (findIndex (x: !pred x) xs) {
       nothing = { _0 = xs; _1 = []; };
       just = n: splitAt n xs;
     };
@@ -817,7 +816,7 @@ rec {
      { _0 = [ 2 4 6 ]; _1 = [ 9 10 11 12 14 ]; }
   */
   break = pred: xs:
-    optional.match (findIndex pred xs) {
+    _optional.match (findIndex pred xs) {
       nothing = { _0 = xs; _1 = []; };
       just = n: splitAt n xs;
     };

--- a/optional.nix
+++ b/optional.nix
@@ -98,9 +98,9 @@ rec {
 
   /* optional a -> bool
   */
-  isJust = x: x.value != null;
+  isJust = x: x._tag == "just";
 
   /* optional a -> bool
   */
-  isNothing = x: x.value == null;
+  isNothing = x: x._tag == "nothing";
 }

--- a/optional.nix
+++ b/optional.nix
@@ -4,7 +4,7 @@ with rec {
 };
 
 /*
-type Optional a = { _tag :: "nothing } | { _tag :: "just", value :: Nullable a }
+type optional a = { _tag :: "nothing" } | { _tag :: "just", value :: Nullable a }
 */
 
 rec {

--- a/optional.nix
+++ b/optional.nix
@@ -64,11 +64,11 @@ rec {
   */
   semigroup = a: {
     append = x: y:
-      if x.value == null
+      if x._tag == "nothing"
       then y
-      else if y.value == null
+      else if y._tag == "nothing"
            then x
-           else { value = a.append x.value y.value; };
+           else { _tag = "just"; value = a.append x.value y.value; };
   };
 
   /* `optional.monoid` recovers a monoid from a semigroup by adding

--- a/optional.nix
+++ b/optional.nix
@@ -4,13 +4,13 @@ with rec {
 };
 
 /*
-type Optional a = { _tag :: "nothing" | "just", value :: Nullable a }
+type Optional a = { _tag :: "nothing } | { _tag :: "just", value :: Nullable a }
 */
 
 rec {
   /* nothing :: Optional a
   */
-  nothing = { _tag = "nothing"; value = null; };
+  nothing = { _tag = "nothing"; };
 
   /* just :: a -> Optional a
   */
@@ -46,14 +46,14 @@ rec {
     /* join :: Optional (Optional a) -> Optional a
     */
     join = m: match m {
-      nothing = { _tag = "nothing"; value = null; };
+      nothing = { _tag = "nothing"; };
       just = x: { _tag = "just"; value = x; };
     };
 
     /* bind :: Optional a -> (a -> Optional b) -> Optional b
     */
     bind = m: k: match m {
-      nothing = { _tag = "nothing"; value = null; };
+      nothing = { _tag = "nothing"; };
       just = k;
     };
   };
@@ -75,7 +75,7 @@ rec {
      `optional.nothing` as the empty element.
   */
   monoid = a: semigroup a // {
-    empty = { _tag = "nothing"; value = null; };
+    empty = { _tag = "nothing"; };
   };
 
   /* match :: Optional a -> { nothing :: b, just :: a -> b } -> b

--- a/regex.nix
+++ b/regex.nix
@@ -41,7 +41,7 @@ rec {
      > regex.match "([[:alpha:]]+)([[:digit:]]+)" "foo123"
      { _tag = "just"; value = [ "foo" "123" ]; }
      > regex.match "([[:alpha:]]+)([[:digit:]]+)" "foobar"
-     { _tag = "nothing"; value = null; }
+     { _tag = "nothing"; }
 
      To check whether or not a string matches a regex, simply check if the
      result of 'match' is non-null:
@@ -56,7 +56,7 @@ rec {
      > regex.match "([[:digit:]])*" "123"
      { _tag = "just"; value = [ "3" ]; }
      > regex.match "([[:digit:]])*" ""
-     { _tag = "nothing"; value = [ null ]; }
+     { _tag = "just"; value = [ null ]; }
   */
   match = re: str: optional.fromNullable (builtins.match re str);
 
@@ -80,7 +80,7 @@ rec {
      > regex.firstMatch "[aeiou]" "foobar"
      { _tag = "just"; value = "o"; }
      > regex.firstMatch "[aeiou]" "xyzzyx"
-     { _tag = "nothing"; value = null; }
+     { _tag = "nothing"; }
   */
   firstMatch = regex: str:
     let res = split (capture regex) str;
@@ -96,7 +96,7 @@ rec {
      > regex.lastMatch "[aeiou]" "foobar"
      { _tag = "just"; value = "a"; }
      > regex.lastMatch "[aeiou]" "xyzzyx"
-     { _tag = "nothing"; value = null; }
+     { _tag = "nothing"; }
   */
   lastMatch = regex: str:
     let

--- a/string.nix
+++ b/string.nix
@@ -215,10 +215,10 @@ rec {
      if no such character is present.
   */
   find = pred: str:
-    let i = (findIndex pred str).value;
-    in if i == null
+    let i = findIndex pred str;
+    in if i._tag == "nothing"
        then _optional.nothing
-       else _optional.just (index str i);
+       else _optional.just (index str i.value);
 
   /* findLast :: (string -> bool) -> string -> Optional string
 
@@ -226,10 +226,10 @@ rec {
      if no such character is present.
   */
   findLast = pred: str:
-    let i = (findLastIndex pred str).value;
-    in if i == null
+    let i = findLastIndex pred str;
+    in if i._tag == "nothing"
        then _optional.nothing
-       else _optional.just (index str i);
+       else _optional.just (index str i.value);
 
   /* escape :: [string] -> string -> string
 
@@ -427,40 +427,40 @@ rec {
      Return the longest prefix of the string that satisfies the predicate.
   */
   takeWhile = pred: str:
-    let n = (findIndex (x: !pred x) str).value;
-    in if n == null
+    let n = findIndex (x: !pred x) str;
+    in if n._tag == "nothing"
       then str
-      else take n str;
+      else take n.value str;
 
   /* dropWhile :: (string -> bool) -> string -> string
 
      Return the rest of the string after the prefix returned by 'takeWhile'.
   */
   dropWhile = pred: str:
-    let n = (findIndex (x: !pred x) str).value;
-    in if n == null
+    let n = findIndex (x: !pred x) str;
+    in if n._tag == "nothing"
       then ""
-      else drop n str;
+      else drop n.value str;
 
   /* takeWhileEnd :: (string -> bool) -> string -> string
 
      Return the longest suffix of the string that satisfies the predicate.
   */
   takeWhileEnd = pred: str:
-    let n = (findLastIndex (x: !pred x) str).value;
-    in if n == null
+    let n = findLastIndex (x: !pred x) str;
+    in if n._tag == "nothing"
       then ""
-      else drop (n + 1) str;
+      else drop (n.value + 1) str;
 
   /* dropWhileEnd :: (string -> bool) -> string -> string
 
      Return the rest of the string after the suffix returned by 'takeWhileEnd'.
   */
   dropWhileEnd = pred: str:
-    let n = (findLastIndex (x: !pred x) str).value;
-    in if n == null
+    let n = findLastIndex (x: !pred x) str;
+    in if n._tag == "nothing"
       then ""
-      else take (n + 1) str;
+      else take (n.value + 1) str;
 
   /* splitAt :: int -> string -> (string, string)
 
@@ -474,10 +474,10 @@ rec {
      of this prefix and the rest of the string.
   */
   span = pred: str:
-    let n = (findIndex (x: !pred x) str).value;
-    in if n == null
+    let n = findIndex (x: !pred x) str;
+    in if n._tag == "nothing"
       then { _0 = str; _1 = ""; }
-      else splitAt n str;
+      else splitAt n.value str;
 
   /* break :: (string -> bool) -> string -> (string, string)
 
@@ -485,10 +485,10 @@ rec {
      return a tuple of this prefix and the rest of the string.
   */
   break = pred: str:
-    let n = (findIndex pred str).value;
-    in if n == null
+    let n = findIndex pred str;
+    in if n._tag == "nothing"
       then { _0 = str; _1 = ""; }
-      else splitAt n str;
+      else splitAt n.value str;
 
   /* reverse :: string -> string
 

--- a/string.nix
+++ b/string.nix
@@ -5,7 +5,7 @@ with rec {
   list = import ./list.nix;
   regex = import ./regex.nix;
   num = import ./num.nix;
-  optional = import ./optional.nix;
+  _optional = import ./optional.nix;
 };
 
 rec {
@@ -187,9 +187,9 @@ rec {
       len = length str;
       go = i:
         if i >= len
-        then optional.nothing
+        then _optional.nothing
         else if pred (index str i)
-             then optional.just i
+             then _optional.just i
              else go (i + 1);
     in go 0;
 
@@ -203,9 +203,9 @@ rec {
       len = length str;
       go = i:
         if i < 0
-        then optional.nothing
+        then _optional.nothing
         else if pred (index str i)
-             then optional.just i
+             then _optional.just i
              else go (i - 1);
     in go (len - 1);
 
@@ -217,8 +217,8 @@ rec {
   find = pred: str:
     let i = (findIndex pred str).value;
     in if i == null
-       then optional.nothing
-       else optional.just (index str i);
+       then _optional.nothing
+       else _optional.just (index str i);
 
   /* findLast :: (string -> bool) -> string -> Optional string
 
@@ -228,8 +228,8 @@ rec {
   findLast = pred: str:
     let i = (findLastIndex pred str).value;
     in if i == null
-       then optional.nothing
-       else optional.just (index str i);
+       then _optional.nothing
+       else _optional.just (index str i);
 
   /* escape :: [string] -> string -> string
 

--- a/test.nix
+++ b/test.nix
@@ -646,8 +646,8 @@ let
       nil = assertEqual [] list.nil;
       cons = assertEqual [1 2 3 4 5] (list.cons 1 [2 3 4 5]);
       uncons = string.unlines [
-        (assertEqual null ((list.uncons [])._0.value))
-        (assertEqual [1 2 3 4 5] (list.snoc [1 2 3 4] 5))
+        (assertEqual optional.nothing (list.uncons []))
+        (assertEqual (optional.just { _0 = 1; _1 = [2 3]; }) (list.uncons [1 2 3]))
       ];
       snoc = assertEqual [1 2 3 4 5] (list.snoc [1 2 3 4] 5);
 

--- a/test.nix
+++ b/test.nix
@@ -1031,6 +1031,18 @@ let
           nothing = "baz";
           just = function.id;
         });
+
+      isJust = string.unlines [
+        (assertEqual true (optional.isJust (optional.just 5)))
+        (assertEqual true (optional.isJust (optional.just null)))
+        (assertEqual false (optional.isJust optional.nothing))
+      ];
+
+      isNothing = string.unlines [
+        (assertEqual false (optional.isNothing (optional.just 5)))
+        (assertEqual false (optional.isNothing (optional.just null)))
+        (assertEqual true (optional.isNothing optional.nothing))
+      ];
     };
 
     string = section "std.string" {

--- a/test.nix
+++ b/test.nix
@@ -722,23 +722,23 @@ let
         (list.unfold (n: if n == 0 then optional.nothing else optional.just { _0 = n; _1 = n - 1; }) 10);
 
       findIndex = string.unlines [
-        (assertEqual 1 (list.findIndex num.even [ 1 2 3 4 ]).value)
-        (assertEqual null (list.findIndex num.even [ 1 3 5 ]).value)
+        (assertEqual (optional.just 1) (list.findIndex num.even [ 1 2 3 4 ]))
+        (assertEqual optional.nothing (list.findIndex num.even [ 1 3 5 ]))
       ];
 
       findLastIndex = string.unlines [
-        (assertEqual 3 (list.findLastIndex num.even [ 1 2 3 4 ]).value)
-        (assertEqual null (list.findLastIndex num.even [ 1 3 5 ]).value)
+        (assertEqual (optional.just 3) (list.findLastIndex num.even [ 1 2 3 4 ]))
+        (assertEqual optional.nothing (list.findLastIndex num.even [ 1 3 5 ]))
       ];
 
       find = string.unlines [
-        (assertEqual 2 (list.find num.even [ 1 2 3 4 ]).value)
-        (assertEqual null (list.find num.even [ 1 3 5 ]).value)
+        (assertEqual (optional.just 2) (list.find num.even [ 1 2 3 4 ]))
+        (assertEqual optional.nothing (list.find num.even [ 1 3 5 ]))
       ];
 
       findLast = string.unlines [
-        (assertEqual 4 (list.findLast num.even [ 1 2 3 4 ]).value)
-        (assertEqual null (list.findLast num.even [ 1 3 5 ]).value)
+        (assertEqual (optional.just 4) (list.findLast num.even [ 1 2 3 4 ]))
+        (assertEqual optional.nothing (list.findLast num.even [ 1 3 5 ]))
       ];
 
       splitAt = assertEqual { _0 = [ 1 ]; _1 = [ 2 3 ]; } (list.splitAt 1 [ 1 2 3 ]);
@@ -952,45 +952,6 @@ let
         (assertEqual (nonempty.make 3 [2 1]) (nonempty.reverse (nonempty.make 1 [2 3])))
         (assertEqual (nonempty.make 1 []) (nonempty.reverse (nonempty.make 1 [])))
       ];
-
-      # unfold = assertEqual [10 9 8 7 6 5 4 3 2 1]
-      #   (list.unfold (n: if n == 0 then optional.nothing else optional.just { _0 = n; _1 = n - 1; }) 10);
-
-      # findIndex = string.unlines [
-      #   (assertEqual 1 (list.findIndex num.even [ 1 2 3 4 ]).value)
-      #   (assertEqual null (list.findIndex num.even [ 1 3 5 ]).value)
-      # ];
-
-      # findLastIndex = string.unlines [
-      #   (assertEqual 3 (list.findLastIndex num.even [ 1 2 3 4 ]).value)
-      #   (assertEqual null (list.findLastIndex num.even [ 1 3 5 ]).value)
-      # ];
-
-      # find = string.unlines [
-      #   (assertEqual 2 (list.find num.even [ 1 2 3 4 ]).value)
-      #   (assertEqual null (list.find num.even [ 1 3 5 ]).value)
-      # ];
-
-      # findLast = string.unlines [
-      #   (assertEqual 4 (list.findLast num.even [ 1 2 3 4 ]).value)
-      #   (assertEqual null (list.findLast num.even [ 1 3 5 ]).value)
-      # ];
-
-      # splitAt = assertEqual { _0 = [ 1 ]; _1 = [ 2 3 ]; } (list.splitAt 1 [ 1 2 3 ]);
-
-      # takeWhile = assertEqual [ 2 4 6 ] (list.takeWhile num.even [ 2 4 6 9 10 11 12 14 ]);
-
-      # dropWhile = assertEqual [ 9 10 11 12 14 ] (list.dropWhile num.even [ 2 4 6 9 10 11 12 14 ]);
-
-      # takeWhileEnd = assertEqual [ 12 14 ] (list.takeWhileEnd num.even [ 2 4 6 9 10 11 12 14 ]);
-
-      # dropWhileEnd = assertEqual [ 2 4 6 9 10 11 ] (list.dropWhileEnd num.even [ 2 4 6 9 10 11 12 14 ]);
-
-      # span = assertEqual { _0 = [ 2 4 6 ]; _1 = [ 9 10 11 12 14 ]; }
-      #   (list.span num.even [ 2 4 6 9 10 11 12 14 ]);
-
-      # break = assertEqual { _0 = [ 2 4 6 ]; _1 = [ 9 10 11 12 14 ]; }
-      #   (list.break num.odd [ 2 4 6 9 10 11 12 14 ]);
     };
 
     optional = section "std.optional" {
@@ -1115,15 +1076,15 @@ let
       map = assertEqual (string.map (x: x + " ") "foo") "f o o ";
       imap = assertEqual (string.imap (i: x: builtins.toJSON i + x) "foo") "0f1o2o";
       filter = assertEqual (string.filter (x: x != " ") "foo bar baz") "foobarbaz";
-      findIndex = assertEqual (string.findIndex (x: x == " ") "foo bar baz").value 3;
-      findLastIndex = assertEqual (string.findLastIndex (x: x == " ") "foo bar baz").value 7;
+      findIndex = assertEqual (string.findIndex (x: x == " ") "foo bar baz") (optional.just 3);
+      findLastIndex = assertEqual (string.findLastIndex (x: x == " ") "foo bar baz") (optional.just 7);
       find = string.unlines [
-        (assertEqual (string.find (x: x == " ") "foo bar baz").value " ")
-        (assertEqual (string.find (x: x == "q") "foo bar baz").value null)
+        (assertEqual (string.find (x: x == " ") "foo bar baz") (optional.just " "))
+        (assertEqual (string.find (x: x == "q") "foo bar baz") optional.nothing)
       ];
       findLast = string.unlines [
-        (assertEqual (string.find (x: x == " ") "foo bar baz").value " ")
-        (assertEqual (string.find (x: x == "q") "foo bar baz").value null)
+        (assertEqual (string.find (x: x == " ") "foo bar baz") (optional.just " "))
+        (assertEqual (string.find (x: x == "q") "foo bar baz") optional.nothing)
       ];
       escape = assertEqual (string.escape ["$"] "foo$bar") "foo\\$bar";
       escapeShellArg = assertEqual (string.escapeShellArg "foo 'bar' baz") "'foo '\\''bar'\\'' baz'";


### PR DESCRIPTION
Fixes the changes made on the representation and uses of optional in 30fb845a4329971e0b9f1fdee79e045e5558d654. Removes `value` from `optional.nothing` (since otherwise you might be tempted to do `x.value == null` for `isNothing`, which breaks on `option (nullable a)`). Fixes references to `optional` in `string`/`list`, where `optional` is already the name of a function.