### PR TITLE
Add indents to test framework to allow for subsections

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,6 @@
     {
       lib = import ./default.nix;
     } // eachDefaultSystem (system: {
-      checks.nix-std-test = import ./test.nix { inherit system; };
+      checks.nix-std-test = import ./test/default.nix { inherit system; };
     });
 }

--- a/test/framework.nix
+++ b/test/framework.nix
@@ -3,12 +3,15 @@ with std;
 
 rec {
   section = module: tests: ''
-    echo "testing ${module}"
-    ${string.concat
-        (list.map
-          (test: ''echo "...${test._0}"...; ${test._1}'')
-            (set.toList tests))
-     }
+    (
+      echo "''${SECTION_INDENT:-}testing ${module}"
+      SECTION_INDENT="''${SECTION_INDENT:-}  "
+      ${string.concat
+          (list.map
+            (test: ''echo "''${SECTION_INDENT}...${test._0}"...; ${test._1}'')
+              (set.toList tests))
+       }
+    )
   '';
 
   assertEqual = x: y:
@@ -29,7 +32,7 @@ rec {
   lawCheck = { lawName, typeName ? null }: x: y:
     if x == y
     then ''
-      printf "[${typeName}] ${lawName}: ✓"
+      printf "  ''${SECTION_INDENT:-}[${typeName}] ${lawName}: ✓"
       echo ""
     ''
     else ''
@@ -40,7 +43,7 @@ rec {
           y = ${string.escape [''"''] (types.show y)}
 
       "
-      printf "[${typeName}] ${lawName}: ✗"
+      printf "  ''${SECTION_INDENT:-}[${typeName}] ${lawName}: ✗"
       printf "$ERR"
       exit 1
     '';


### PR DESCRIPTION
As a followup to 9c7a18b753018e60825146d07316a8990585e538, this is a proposal/POC to add some indentation to the output of the testing framework.

The output would look like this (details could obviously be adjusted for better grouping):
```
testing std.list
  ...all...
  ...any...
  ...break...
  ...laws...
    [list] functor identity: ✓
    [list] functor composition: ✓
    [list] applicative identity: ✓
    [list] applicative composition: ✓
    [list] applicative homomorphism: ✓
  ...length...
  ...map...
```

This buys subsections for free; before, you couldn't include a section as a value inside of a section, since the output would be mixed, like:

```
testing std.num
...abs...
...ceil...
...compare...
testing std.num.bits
...bit...
...bitAnd...
...bitNot...
...div...  // it switches back to std.num here
...divMod...
```

With the proposal, it would nest properly:

```
testing std.num
  ...abs...
  ...ceil...
  ...compare...
  testing std.num.bits
    ...bit...
    ...bitAnd...
    ...bitNot...
  ...div...
  ...divMod...
```

Also fixes the reference to `test.nix` in the flake checks while I'm at it. Feel free to cherry-pick that if the rest is going to be discarded.