### PR TITLE
Add basic flake info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,27 @@ no-nixpkgs standard library for the nix expression language.
 
 ## Usage
 
+Fetch using plain Nix:
+
 ```nix
 with {
   std = import (builtins.fetchTarball {
     url = "https://github.com/chessai/nix-std/archive/v0.0.0.1.tar.gz";
     sha256 = "0vglyghzj19240flribyvngmv0fyqkxl8pxzyn0sxlci8whmc9fr"; });
 };
+```
+
+Or, if using flakes, add it to your flake inputs:
+
+```nix
+{
+  inputs.nix-std.url = "github:chessai/nix-std";
+  outputs = { self, nix-std }:
+    let
+      std = nix-std.lib;
+    in
+    {
+      # ...
+    };
+}
 ```


### PR DESCRIPTION
Even though they're still unstable, flakes are popular enough now that they may merit a brief mention in the README.