### PR TITLE
Fix framework not exiting on failed tests

### DIFF
--- a/test/framework.nix
+++ b/test/framework.nix
@@ -11,7 +11,7 @@ rec {
             (test: ''echo "''${SECTION_INDENT}...${test._0}"...; ${test._1}'')
               (set.toList tests))
        }
-    )
+    ) || exit $?
   '';
 
   assertEqual = x: y:


### PR DESCRIPTION
#18 had a small bug that prevented the framework from properly exiting when tests failed due to the subshell used; this is a fix that reintroduces proper exit behavior.