### PR TITLE
Implement ADT framework

### DIFF
--- a/adt.nix
+++ b/adt.nix
@@ -1,0 +1,86 @@
+let
+  list = import ./list.nix;
+  set = import ./set.nix;
+
+  applyList = f: xs: list.foldl' (f': x: f' x) f xs;
+in
+{
+  /*
+     create a new algebraic data type based on a specification.
+
+     examples:
+
+     > adt.new "optional" { just = [ "value" ]; nothing = null; }
+     > adt.new "result" { ok = 1; err = 1; }
+     > adt.new "pair" { make = 2; }
+     > adt.new "point" { make = { x = null; y = null; }; }
+  */
+  new = name: constructors:
+    assert builtins.isAttrs constructors;
+    assert builtins.all
+      (spec:
+        builtins.any (x: x) [
+          (spec == null)
+          (builtins.isList spec && builtins.all builtins.isString spec)
+          (builtins.isAttrs spec && builtins.all (x: x == null) (builtins.attrValues spec))
+          (builtins.isInt spec && spec > 0)
+        ]
+      )
+      (builtins.attrValues constructors);
+    assert builtins.all (name: name != "_tag") (builtins.attrNames constructors);
+    let
+      needsTag = builtins.length (builtins.attrNames constructors) > 1;
+      genNaryCtor = base: args:
+        let
+          len = builtins.length args;
+          go = acc: i:
+            if i >= len
+            then acc
+            else
+              let
+                field = builtins.elemAt args i;
+              in x: go (acc // { ${field} = x; }) (i + 1);
+        in go base 0;
+      makeCtor = ctorName: spec:
+        let
+          baseAttrs = if needsTag then { _tag = ctorName; } else {};
+        in
+          if spec == null then
+            # nullary
+            baseAttrs
+          else if builtins.isList spec then
+            # positional, struct field named by string
+            genNaryCtor baseAttrs spec
+          else if builtins.isAttrs spec then
+            # one attrset argument, fields named by strings both ways
+            # TODO: could just intersectAttrs here, but wouldn't get checking that
+            # all keys are present
+            args: list.foldl' (x: y: x // { ${y} = args.${y}; }) baseAttrs (builtins.attrNames spec)
+          else if builtins.isInt spec then
+            genNaryCtor baseAttrs (list.map (n: "_${builtins.toString n}") (list.range 0 (spec - 1)))
+          else builtins.throw "std.adt.new: invalid constructor specification for '${ctorName}'";
+      ctors = set.map makeCtor constructors;
+      match =
+        let
+          makeApply = _: spec:
+            if spec == null then
+              # nullary
+              (f: _: f)
+            else if builtins.isList spec then
+              (f: v: f (list.foldl' (x: y: x // y) {} (list.map (k: { ${k} = v.${k}; }) spec)))
+            else if builtins.isAttrs spec then
+              (f: v: f (set.map (k: _: v.${k})))
+            else # int
+              (f: v: applyList f (list.map (k: v."_${builtins.toString k}") (list.range 0 (spec - 1))))
+            ;
+          apply = set.map makeApply constructors;
+          only = as: as.${builtins.head (builtins.attrNames as)};
+        in
+          if builtins.length (builtins.attrNames constructors) == 0 then
+            builtins.throw "std.adt: match on empty ADT: ${name}"
+          else if !needsTag then
+            val: matches: (only apply) (only matches) val # TODO: should this be an attrset of matches?
+          else
+            val: matches: apply.${val._tag} matches.${val._tag} val;
+    in { inherit match ctors; };
+}

--- a/adt.nix
+++ b/adt.nix
@@ -133,21 +133,21 @@ rec {
      Examples:
 
      > adt.new "optional" {
-         just = adt.fields.positional [ "value" ];
+         just = adt.fields.positional_ [ "value" ];
          nothing = adt.fields.none;
        }
 
      > adt.new "result" {
-         ok = adt.fields.anon 1;
-         err = adt.fields.anon 1;
+         ok = adt.fields.anon_ 1;
+         err = adt.fields.anon_ 1;
        }
 
      > adt.new "pair" {
-         make = adt.fields.anon 2;
+         make = adt.fields.anon_ 2;
        }
 
      > adt.new "point" {
-         make = adt.fields.record [ "x" "y" ];
+         make = adt.fields.record_ [ "x" "y" ];
        }
   */
   new = name: constructors:

--- a/adt.nix
+++ b/adt.nix
@@ -227,13 +227,9 @@ rec {
                 matcher =
                   if builtins.isAttrs matches then
                     only matches
-                  else if builtins.isFunction matches then
-                    matches
                   else
-                    builtins.throw "std.adt: invalid matcher for ${string.escapeNixString name}";
-              in if only constructors == null
-                then matches
-                else (only apply) matcher val
+                    builtins.throw "std.adt: expected attrset for matcher on ${string.escapeNixString name}";
+              in (only apply) matcher val
           else
             val: matches:
               if builtins.isAttrs matches then

--- a/adt.nix
+++ b/adt.nix
@@ -17,7 +17,7 @@ rec {
        the constructor and match function both expect appropriate positional
        arguments. The field names are only used in the internal representation.
 
-       > point = adt.struct "point" (adt.fields.positional [{ name = "x"; type = types.float; } { name = "y"; type = types.float; }])
+       > point = adt.struct "point" (adt.fields.positional [{ name = "x"; type = types.int; } { name = "y"; type = types.int; }])
        > p = point.ctors.make 1 2
        > p
        { _type = "point"; x = 1; y = 2; }
@@ -50,7 +50,7 @@ rec {
        the constructor and match function both expect a single attrset argument
        with the appropriate fields.
 
-       > point = adt.struct "point" (adt.fields.record { x = types.float; y = types.float; })
+       > point = adt.struct "point" (adt.fields.record { x = types.int; y = types.int; })
        > p = point.ctors.make { x = 1; y = 2; }
        > p
        { _type = "point"; x = 1; y = 2; }
@@ -91,7 +91,7 @@ rec {
        Like `fields.positional`, but instead of providing the names for the
        fields, the given number of anonymous field names are used instead.
 
-       > point = adt.struct "point" (adt.fields.anon [types.float types.float])
+       > point = adt.struct "point" (adt.fields.anon [types.int types.int])
        > p = point.ctors.make 1 2
        > p
        { _type = "point"; _0 = 1; _1 = 2; }

--- a/adt.nix
+++ b/adt.nix
@@ -1,21 +1,125 @@
 let
   list = import ./list.nix;
   set = import ./set.nix;
+  string = import ./string.nix;
 
-  applyList = f: xs: list.foldl' (f': x: f' x) f xs;
+  unique = xs:
+    let
+      xs' = builtins.sort builtins.lessThan xs;
+    in builtins.length xs <= 1 || list.all (x: x) (list.zipWith (x: y: x != y) xs' (list.tail xs'));
 in
-{
-  /*
-     create a new algebraic data type based on a specification.
+rec {
+  fields = rec {
+    /* positional :: [string] -> ConstructorSpecification
 
-     examples:
+       Specifies that the variant should contain the provided field names, but
+       the constructor and match function both expect appropriate positional
+       arguments. The field names are only used in the internal representation.
 
-     > adt.new "optional" { just = [ "value" ]; nothing = null; }
-     > adt.new "result" { ok = 1; err = 1; }
-     > adt.new "pair" { make = 2; }
-     > adt.new "point" { make = { x = null; y = null; }; }
+       > point = adt.struct "point" (adt.fields.positional ["x" "y"])
+       > p = point.ctors.make 1 2
+       > p
+       { _type = "point"; x = 1; y = 2; }
+       > point.match p (x: y: x + y)
+       3
+    */
+    positional = fields:
+      assert builtins.isList fields && builtins.all builtins.isString fields;
+      assert unique fields;
+      fields;
+
+    /* record :: [string] -> ConstructorSpecification
+
+       Specifies that the variant should contain the provided field names, but
+       the constructor and match function both expect a single attrset argument
+       with the appropriate fields.
+
+       > point = adt.struct "point" (adt.fields.record ["x" "y"])
+       > p = point.ctors.make { x = 1; y = 2; }
+       > p
+       { _type = "point"; x = 1; y = 2; }
+       > point.match p ({ x, y }: x + y)
+       3
+    */
+    record = fields:
+      assert builtins.isList fields && builtins.all builtins.isString fields;
+      assert unique fields;
+      list.fold set.monoid (list.map (x: { ${x} = null; }) fields);
+
+    /* none :: ConstructorSpecification
+
+       Specifies that the variant should contain no fields. The constructor will
+       not be a function, but a singleton attrset. The corresponding match
+       branch will expect a value, not a function, when matching.
+
+       > optional = adt.enum "optional" { just = adt.fields.positional ["value"]; nothing = adt.fields.none; }
+       > optional.ctors.just 5
+       { _tag = "just"; _type = "optional"; value = 5; }
+       > optional.ctors.nothing
+       { _tag = "nothing"; _type = "optional"; }
+       > optional.match optional.ctors.nothing { just = x: x + 2; nothing = 7; }
+       7
+    */
+    none = null;
+
+    /* anon :: int -> ConstructorSpecification
+
+       Like `fields.positional`, but instead of providing the names for the
+       fields, the given number of anonymous field names are used instead.
+
+       > point = adt.struct "point" (adt.fields.anon 2)
+       > p = point.ctors.make 1 2
+       > p
+       { _type = "point"; _0 = 1; _1 = 2; }
+       > point.match p (x: y: x + y)
+       3
+    */
+    anon = x:
+      assert builtins.isInt x && x > 0;
+      positional (list.map (n: "_${builtins.toString n}") (list.range 0 (x - 1)));
+  };
+
+  /* struct :: string -> ConstructorSpecification -> ADT
+
+     Create a new algebraic data type with one one constructor, named 'make'.
+  */
+  struct = name: constructor: new name { make = constructor; };
+
+  /* enum :: string -> { string: ConstructorSpecification } -> ADT
+
+     Create a new algebraic data type consisting of a sum type with the
+     constructors provided. This is simply an alias for 'new' to communicate
+     intention when a sum type is being created.
+  */
+  enum = new;
+
+  /* new :: string -> { string: ConstructorSpecification } -> ADT
+
+     Create a new algebraic data type based on a specification of its
+     constructors.
+
+     Examples:
+
+     > adt.new "optional" {
+         just = adt.fields.positional [ "value" ];
+         nothing = adt.fields.none;
+       }
+
+     > adt.new "result" {
+         ok = adt.fields.anon 1;
+         err = adt.fields.anon 1;
+       }
+
+     > adt.new "pair" {
+         make = adt.fields.anon 2;
+       }
+
+     > adt.new "point" {
+         make = adt.fields.record [ "x" "y" ];
+       }
   */
   new = name: constructors:
+    assert builtins.isString name;
     assert builtins.isAttrs constructors;
     assert builtins.all
       (spec:
@@ -23,7 +127,6 @@ in
           (spec == null)
           (builtins.isList spec && builtins.all builtins.isString spec)
           (builtins.isAttrs spec && builtins.all (x: x == null) (builtins.attrValues spec))
-          (builtins.isInt spec && spec > 0)
         ]
       )
       (builtins.attrValues constructors);
@@ -41,6 +144,7 @@ in
                 field = builtins.elemAt args i;
               in x: go (acc // { ${field} = x; }) (i + 1);
         in go base 0;
+      applyList = f: xs: list.foldl' (f': x: f' x) f xs;
       makeCtor = ctorName: spec:
         let
           baseAttrs = if needsTag then { _tag = ctorName; _type = name; } else { _type = name; };
@@ -56,9 +160,7 @@ in
             # TODO: could just intersectAttrs here, but wouldn't get checking that
             # all keys are present
             args: list.foldl' (x: y: x // { ${y} = args.${y}; }) baseAttrs (builtins.attrNames spec)
-          else if builtins.isInt spec then
-            genNaryCtor baseAttrs (list.map (n: "_${builtins.toString n}") (list.range 0 (spec - 1)))
-          else builtins.throw "std.adt.new: invalid constructor specification for '${ctorName}'";
+          else builtins.throw "std.adt.new: invalid constructor specification for constructor ${string.escapeNixString ctorName}";
       ctors = set.map makeCtor constructors;
       match =
         let
@@ -67,20 +169,31 @@ in
               # nullary
               (f: _: f)
             else if builtins.isList spec then
-              (f: v: f (list.foldl' (x: y: x // y) {} (list.map (k: { ${k} = v.${k}; }) spec)))
-            else if builtins.isAttrs spec then
-              (f: v: f (set.map (k: _: v.${k})))
-            else # int
-              (f: v: applyList f (list.map (k: v."_${builtins.toString k}") (list.range 0 (spec - 1))))
+              (f: v: applyList f (list.map (k: v.${k}) spec))
+            else # attrs
+              (f: v: f (set.map (k: _: v.${k}) spec))
             ;
           apply = set.map makeApply constructors;
           only = as: as.${builtins.head (builtins.attrNames as)};
         in
           if builtins.length (builtins.attrNames constructors) == 0 then
-            builtins.throw "std.adt: match on empty ADT: ${name}"
+            builtins.throw "std.adt: match on empty ADT: ${string.escapeNixString name}"
           else if !needsTag then
-            val: matches: (only apply) (only matches) val # TODO: should this be an attrset of matches?
+            val: matches:
+              let
+                matcher =
+                  if builtins.isAttrs matches then
+                    only matches val
+                  else if builtins.isFunction matches then
+                    matches
+                  else
+                    builtins.throw "std.adt: expected function or attrset for matcher on ${string.escapeNixString name}";
+              in (only apply) matcher val
           else
-            val: matches: apply.${val._tag} matches.${val._tag} val;
+            val: matches:
+              if builtins.isAttrs matches then
+                apply.${val._tag} matches.${val._tag} val
+              else
+                builtins.throw "std.adt: expected attrset for matcher on ${string.escapeNixString name}";
     in { inherit match ctors; };
 }

--- a/adt.nix
+++ b/adt.nix
@@ -117,13 +117,22 @@ rec {
   */
   struct = name: constructor: new name { make = constructor; };
 
-  /* enum :: string -> { string: ConstructorSpecification } -> ADT
+  /* enum :: string -> { string: ConstructorSpecification } | [ string ] -> ADT
 
-     Create a new algebraic data type consisting of a sum type with the
-     constructors provided. This is simply an alias for 'new' to communicate
-     intention when a sum type is being created.
+     Create a new algebraic data type, with the provided constructors acting as
+     variants of the sum type. The constructor specification, if an attribute
+     set, has the same format as 'adt.new'. If the constructor specification is
+     a list of strings, each constructor will be assumed to be unary; that is,
+     each will be specified to 'adt.fields.none'.
   */
-  enum = new;
+  enum = name: ctors:
+    if builtins.isList ctors then
+      assert builtins.all builtins.isString ctors;
+      let
+        toUnary = ctorName: { "${ctorName}" = fields.none; };
+      in new name (list.fold set.monoid (list.map toUnary ctors))
+    else
+      new name ctors;
 
   /* new :: string -> { string: ConstructorSpecification } -> ADT
 

--- a/adt.nix
+++ b/adt.nix
@@ -27,7 +27,7 @@ in
         ]
       )
       (builtins.attrValues constructors);
-    assert builtins.all (name: name != "_tag") (builtins.attrNames constructors);
+    assert builtins.all (name: !builtins.elem name [ "_tag" "_type" ]) (builtins.attrNames constructors);
     let
       needsTag = builtins.length (builtins.attrNames constructors) > 1;
       genNaryCtor = base: args:
@@ -43,7 +43,7 @@ in
         in go base 0;
       makeCtor = ctorName: spec:
         let
-          baseAttrs = if needsTag then { _tag = ctorName; } else {};
+          baseAttrs = if needsTag then { _tag = ctorName; _type = name; } else { _type = name; };
         in
           if spec == null then
             # nullary

--- a/adt.nix
+++ b/adt.nix
@@ -230,8 +230,10 @@ rec {
                   else if builtins.isFunction matches then
                     matches
                   else
-                    builtins.throw "std.adt: expected function or attrset for matcher on ${string.escapeNixString name}";
-              in (only apply) matcher val
+                    builtins.throw "std.adt: invalid matcher for ${string.escapeNixString name}";
+              in if only constructors == null
+                then matches
+                else (only apply) matcher val
           else
             val: matches:
               if builtins.isAttrs matches then

--- a/adt.nix
+++ b/adt.nix
@@ -226,7 +226,7 @@ rec {
               let
                 matcher =
                   if builtins.isAttrs matches then
-                    only matches val
+                    only matches
                   else if builtins.isFunction matches then
                     matches
                   else

--- a/adt.nix
+++ b/adt.nix
@@ -21,7 +21,7 @@ rec {
        > p = point.ctors.make 1 2
        > p
        { _type = "point"; x = 1; y = 2; }
-       > point.match p (x: y: x + y)
+       > point.match p { make = x: y: x + y; }
        3
     */
     positional = fields:
@@ -54,7 +54,7 @@ rec {
        > p = point.ctors.make { x = 1; y = 2; }
        > p
        { _type = "point"; x = 1; y = 2; }
-       > point.match p ({ x, y }: x + y)
+       > point.match p { make = { x, y }: x + y; }
        3
     */
     record = fields:
@@ -95,7 +95,7 @@ rec {
        > p = point.ctors.make 1 2
        > p
        { _type = "point"; _0 = 1; _1 = 2; }
-       > point.match p (x: y: x + y)
+       > point.match p { make x: y: x + y; }
        3
     */
     anon = types:

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,6 @@
 rec {
+  adt = import ./adt.nix;
+
   applicative = import ./applicative.nix;
 
   bool = import ./bool.nix;

--- a/types.nix
+++ b/types.nix
@@ -94,6 +94,12 @@ rec {
     inherit name check description show;
   };
 
+  any = {
+    name = "any";
+    check = _: true;
+    description = "any value";
+  };
+
   bool = mkType {
     name = "bool";
     description = "boolean";


### PR DESCRIPTION
Tracking PR for WIP implementation of automatic ADT generation.

Currently, the API is as follows:

* Call `adt.new` with a set of constructor names to constructor specifications to automatically generate an ADT. The returned set includes a match function, a check function, and an attrset of the constructors
  * `adt.struct` is shorthand for ADTs with only one constructor, and names the constructor `make`.

* Every constructor has a specification for its fields, which can be typed or untyped. Available specifications are in `adt.fields`.
  * `positional [ { name = "x"; type = types.int; } { name = "y"; type = types.int; } ]` would make a constructor like `make 1 2`, and a match function like `{ make = x: y: ...; }`
  * `positional_ [ "x" "y" ]` is the same, but untyped
  * `record { x = types.int; y = types.int }` would make a constructor like `make { x = 1; y =  2; }`, and a match function like `{ make = { x, y }: ...; }`
  * `record_ ["x" "y"]` is the same, but untyped
  * `none` is for unary constructors, like `adt.struct "unit" adt.fields.none`
  * `anon [ types.int types.int ]` is like `positional`, but the internal field names are automatically generated
  * `anon_ 2` is like `positional_`, but the internal field names are automatically generated

* Currently, the only typechecking is via `check`. Constructors do not typecheck their arguments, since this would be awful for slow-to-check types. `check` will check both the field types and `adt`'s autogenerated annotations

* `match` is used the same as `list.match`, etc. While `match` could hypothetically be a key in the value, I kept it separate for consistency with these functions.

Some questions to answer:

1. Which operations should be typechecked? Should typechecking occur anywhere else other than `check`?
1. Should `adt.struct` name the single constructor `make`, `new`, etc., or name it after the type name? For example, `unit = adt.struct "unit" adt.fields.none` would currently have `unit.ctors.make`, which doesn't make too much sense, but the user can always unpack the result and rename everything.
1. Pattern matching on a single-constructor type like those generated by `adt.struct` used to allow optionally using a plain function (e.g. `point.match p (x: y: x + y)`) instead of the full single-element attrset (e.g. `point.match p { make = x: y: x + y; }`) but this was found to be ambiguous on types with one value, where you naturally could just use a value here. For example, should `unit.match x { make = 5; }` return `5` or `{ make = 5; }`? As a solution, I temporarily removed the shorthand. One possible solution is to arbitrarily require a one-argument function for such a type that we arbitrarily pass `null` to, but this is pretty inconsistent and not that great either.
1. What should be the format of the return value be? Should the constructors go at the top level, or should they stay inside a `ctors` field and we just have the user unpack everything into the API they want to expose?
1. Should we also expose some custom `__toString`? Could we support user-generated `__toString`s?
1. Several of our implicit types could benefit from ADTs, like `adt.new "ordering" { gt = adt.fields.none; eq = adt.fields.none; lt = adt.fields.none; }`. Where would we put these?

Also could use tests and much better docs.