### PR TITLE
set.fromList and std.tuple

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -37,6 +37,8 @@ rec {
 
   string = import ./string.nix;
 
+  tuple = import ./tuple.nix;
+
   types = import ./types.nix;
 
   version = import ./version.nix;

--- a/set.nix
+++ b/set.nix
@@ -2,6 +2,7 @@ with rec {
   function = import ./function.nix;
   inherit (function) id;
   list = import ./list.nix;
+  tuple = import ./tuple.nix;
 };
 
 rec {
@@ -56,4 +57,8 @@ rec {
   /* toList :: set -> [(key, value)]
   */
   toList = s: list.map (k: { _0 = k; _1 = s.${k}; }) (keys s);
+
+  /* fromList :: [(key, value)] -> set
+  */
+  fromList = xs: builtins.listToAttrs (list.map tuple.toPair xs);
 }

--- a/test/sections/default.nix
+++ b/test/sections/default.nix
@@ -8,5 +8,7 @@
   optional = import ./optional.nix;
   regex = import ./regex.nix;
   serde = import ./serde.nix;
+  set = import ./set.nix;
   string = import ./string.nix;
+  tuple = import ./tuple.nix;
 }

--- a/test/sections/set.nix
+++ b/test/sections/set.nix
@@ -1,0 +1,14 @@
+with { std = import ./../../default.nix; };
+with std;
+
+with (import ./../framework.nix);
+
+section "std.set" {
+  toList = let
+    s = { a = 0; };
+    xs = [ { _0 = "a"; _1 = 0; } ];
+  in string.unlines [
+    (assertEqual (set.fromList xs) s)
+    (assertEqual (set.toList s) xs)
+  ];
+}

--- a/test/sections/tuple.nix
+++ b/test/sections/tuple.nix
@@ -1,0 +1,8 @@
+with { std = import ./../../default.nix; };
+with std;
+
+with (import ./../framework.nix);
+
+section "std.tuple" {
+  fromList = assertEqual (tuple.fromList [ 0 1 ]) { _0 = 0; _1 = 1; };
+}

--- a/tuple.nix
+++ b/tuple.nix
@@ -1,0 +1,24 @@
+with rec {
+  list = import ./list.nix;
+  set = import ./set.nix;
+  tuple = import ./tuple.nix;
+};
+
+rec {
+  /* empty :: tuple
+  */
+  empty = set.empty;
+
+  /* new2 :: _0 -> _1 -> (_0, _1)
+  */
+  new2 = _0: _1: { inherit _0 _1; };
+
+  /* fromList :: [a] -> tuple
+  */
+  fromList = xs: set.fromList (list.imap (i: tuple.new2 "_${toString i}") xs);
+
+  /* toPair :: (key, value) -> pair
+    Converts a tuple to the argument required by `builtins.listToAttrs`
+  */
+  toPair = { _0, _1 }: { name = _0; value = _1; };
+}


### PR DESCRIPTION
is the addition of `tuple` too excessive? `tuple.toPair` could of course just be inlined...

(it also may be preferred to use different encoding for tuples and make them recursive/lazy instead, reconsider empty/unit tuples, etc. so feel free to suggest improvements)