### PR TITLE
Fix and test optional.toNullable

### DIFF
--- a/optional.nix
+++ b/optional.nix
@@ -94,7 +94,7 @@ rec {
 
   /* toNullable :: optional a -> nullable a
   */
-  toNullable = x: x.value;
+  toNullable = x: x.value or null;
 
   /* optional a -> bool
   */

--- a/test/sections/optional.nix
+++ b/test/sections/optional.nix
@@ -92,4 +92,9 @@ section "std.optional" {
     (assertEqual false (optional.isNothing (optional.just null)))
     (assertEqual true (optional.isNothing optional.nothing))
   ];
+
+  toNullable = string.unlines [
+    (assertEqual 1 (optional.toNullable (optional.just 1)))
+    (assertEqual null (optional.toNullable optional.nothing))
+  ];
 }


### PR DESCRIPTION
`optional.nothing` does not contain a `.value` attr