### PR TITLE
set.mapToValues

### DIFF
--- a/set.nix
+++ b/set.nix
@@ -1,6 +1,6 @@
 with rec {
   function = import ./function.nix;
-  inherit (function) id flip;
+  inherit (function) id flip compose;
   list = import ./list.nix;
 };
 
@@ -70,6 +70,10 @@ rec {
     }) names);
     zipAttrsWith = f: sets: zipAttrsWithNames (list.concatMap keys sets) f sets;
   in builtins.zipAttrsWith or zipAttrsWith;
+
+  /* mapToValues :: (key -> value -> a) -> set -> [a]
+  */
+  mapToValues = f: compose values (map f);
 
   /* filter :: (key -> value -> bool) -> set -> set
   */

--- a/test/sections/set.nix
+++ b/test/sections/set.nix
@@ -17,6 +17,7 @@ in section "std.set" {
   zip = assertEqual { a = [0 1]; b = [1]; c = [2]; } (set.mapZip (_: function.id) [testSet { a = 1; }]);
   without = assertEqual { b = 1; c = 2; } (set.without [ "a" ] testSet);
   retain = assertEqual { a = 0; } (set.retain [ "a" ] testSet);
+  mapToValues = assertEqual [ 1 2 3 ] (set.mapToValues (_: num.add 1) testSet);
   filter = assertEqual { b = 1; } (set.filter (k: v: v == 1) testSet);
   traverse = assertEqual testSet (set.traverse nullable.applicative (x: if (num.even x || num.odd x) then x else null) testSet);
   toList = assertEqual [


### PR DESCRIPTION
`nixpkgs.lib.mapAttrsToList` equivalent

I'm not so sure about the name, something like `mapToValues` might be more appropriate? `set.toList` returns a tuple, so it's weird for this not to.