### PR TITLE
set attrname black/whitelists

### DIFF
--- a/set.nix
+++ b/set.nix
@@ -77,6 +77,14 @@ rec {
     value = s.${name};
   in list.optional (f name value) { inherit name value; }) (keys s));
 
+  /* without :: [key] -> set -> set
+  */
+  without = flip builtins.removeAttrs;
+
+  /* retain :: [key] -> set -> set
+  */
+  retain = keys: builtins.intersectAttrs (gen keys id);
+
   /* traverse :: Applicative f => (value -> f b) -> set -> f set
   */
   traverse = ap: f:

--- a/test/sections/set.nix
+++ b/test/sections/set.nix
@@ -15,6 +15,8 @@ in section "std.set" {
   values = assertEqual [0 1 2] (set.values testSet);
   map = assertEqual { a = 1; b = 2; c = 3; } (set.map (_: num.add 1) testSet);
   zip = assertEqual { a = [0 1]; b = [1]; c = [2]; } (set.mapZip (_: function.id) [testSet { a = 1; }]);
+  without = assertEqual { b = 1; c = 2; } (set.without [ "a" ] testSet);
+  retain = assertEqual { a = 0; } (set.retain [ "a" ] testSet);
   filter = assertEqual { b = 1; } (set.filter (k: v: v == 1) testSet);
   traverse = assertEqual testSet (set.traverse nullable.applicative (x: if (num.even x || num.odd x) then x else null) testSet);
   toList = assertEqual [


### PR DESCRIPTION
These are basically `builtins.removeAttrs` and `nixpkgs.lib.getAttrs`, so feel free to give an opinion on names for these. Some combinations that come to mind:
- `without`, `with`
- `without`, `only`
- `remove`, `keep`
- `lose`, `retain`
- `removeKeys`, `getKeys`
- `blacklist`, `whitelist`