### PR TITLE
function tests, args, and functor handling

### DIFF
--- a/test/sections/default.nix
+++ b/test/sections/default.nix
@@ -2,6 +2,7 @@
   bool = import ./bool.nix;
   bits = import ./bits.nix;
   fixpoints = import ./fixpoints.nix;
+  function = import ./function.nix;
   list = import ./list.nix;
   nonempty = import ./nonempty.nix;
   num = import ./num.nix;

--- a/test/sections/function.nix
+++ b/test/sections/function.nix
@@ -1,0 +1,34 @@
+with { std = import ./../../default.nix; };
+with std;
+
+with (import ./../framework.nix);
+
+let
+  testFn = { a, b, c ? 1 }: a + b + c;
+  testFnSet = {
+    __functor = _: testFn;
+    foo = "bar";
+  };
+  testArgs = { a = 0; b = 1; };
+in section "std.function" {
+  callable = string.unlines [
+    (assertEqual 2 (testFn testArgs))
+    (assertEqual 2 (testFnSet testArgs))
+  ];
+  isLambda = string.unlines [
+    (assertEqual true (builtins.isFunction testFn))
+    (assertEqual false (builtins.isFunction testFnSet))
+  ];
+  args = string.unlines [
+    (assertEqual { a = false; b = false; c = true; } (function.args testFn))
+    (assertEqual { a = false; b = false; c = true; } (function.args testFnSet))
+  ];
+  setArgs = assertEqual { a = false; b = false; } (function.args (
+    function.setArgs (set.without ["c"] (function.args testFn)) testFn
+  ));
+  toFunctionSet = string.unlines [
+    (assertEqual true ((function.toSet testFnSet) ? foo))
+    (assertEqual 2 (function.toSet testFn testArgs))
+    (assertEqual 2 (function.toSet testFnSet testArgs))
+  ];
+}


### PR DESCRIPTION
This exposes `builtins.functionArgs` with support for functors, much like `nixpkgs.lib.functionArgs` and its related helpers. While `functor` is nix's term for callable attrsets, it may be an overloaded term since `std` already uses it differently - does that make these function names confusing?

Also the types in these docs could maybe use some improvements?