### PR TITLE
types.function

### DIFF
--- a/function.nix
+++ b/function.nix
@@ -1,5 +1,6 @@
 with {
   set = import ./set.nix;
+  types = import ./types.nix;
 };
 
 rec {
@@ -49,7 +50,7 @@ rec {
      > function.toSet function.id // { foo = "bar"; }
      { __functor = «lambda»; foo = "bar"; }
   */
-  toSet = f: if builtins.isFunction f then {
+  toSet = f: if types.lambda.check f then {
     __functor = self: f;
   } else f;
 }

--- a/test/sections/function.nix
+++ b/test/sections/function.nix
@@ -15,9 +15,17 @@ in section "std.function" {
     (assertEqual 2 (testFn testArgs))
     (assertEqual 2 (testFnSet testArgs))
   ];
-  isLambda = string.unlines [
-    (assertEqual true (builtins.isFunction testFn))
-    (assertEqual false (builtins.isFunction testFnSet))
+  check = string.unlines [
+    (assertEqual true (types.function.check testFn))
+    (assertEqual true (types.lambda.check testFn))
+    (assertEqual false (types.functionSet.check testFn))
+    (assertEqual true (types.function.check testFnSet))
+    (assertEqual true (types.functionSet.check testFnSet))
+    (assertEqual false (types.lambda.check testFnSet))
+  ];
+  show = string.unlines [
+    (assertEqual "«lambda»" (types.function.show function.id))
+    (assertEqual "{ a, b, c ? «code» }: «code»" (types.function.show testFn))
   ];
   args = string.unlines [
     (assertEqual { a = false; b = false; c = true; } (function.args testFn))
@@ -30,5 +38,6 @@ in section "std.function" {
     (assertEqual true ((function.toSet testFnSet) ? foo))
     (assertEqual 2 (function.toSet testFn testArgs))
     (assertEqual 2 (function.toSet testFnSet testArgs))
+    (assertEqual true (types.functionSet.check (function.toSet testFn)))
   ];
 }

--- a/types.nix
+++ b/types.nix
@@ -9,6 +9,7 @@ with rec {
 let
   imports = {
     bool = import ./bool.nix;
+    function = import ./function.nix;
     list = import ./list.nix;
     nonempty = import ./nonempty.nix;
     num = import ./num.nix;
@@ -16,10 +17,10 @@ let
     string = import ./string.nix;
     types = import ./types.nix;
   };
+  inherit (imports.function) const;
   _null = null;
 
   /* unsafe show functions */
-  showFunction = const "<<lambda>>";
   showList = show: ls:
     let body = imports.string.intercalate ", " (imports.list.map show ls);
         tokens = [ "[" ] ++ imports.list.optional (! imports.list.empty ls) body ++ [ "]" ];
@@ -33,10 +34,11 @@ let
   showNonEmpty = show: x:
     "nonempty " + showList show (imports.nonempty.toList x);
   typeShows = imports.set.map (_: imports.nonempty.singleton) {
-    inherit (imports.types) bool float int null list path;
-    lambda = { check = builtins.isFunction; show = showFunction; };
-    set = imports.types.attrs;
+    inherit (imports.types) bool float int null list path lambda;
   } // {
+    set = imports.nonempty.make imports.types.attrs [
+      imports.types.functionSet
+    ];
     string = imports.nonempty.make imports.types.string [
       imports.types.path
     ];
@@ -236,7 +238,7 @@ rec {
     in mkType {
          name = "enum";
          description = "one of ${imports.string.concatMapSep ", " showType values}";
-         check = flip imports.list.elem values;
+         check = imports.function.flip imports.list.elem values;
        };
 
   either = a: b: mkType {
@@ -252,4 +254,30 @@ rec {
           cons = x: xs: tuple2 x xs;
         };
     in imports.list.foldl' either ht._0 ht._1;
+
+  function = mkType {
+    name = "function";
+    description = "function";
+    check = f: lambda.check f || functionSet.check f;
+    show = f: let
+      args = imports.function.args f;
+      showArg = k: isOptional: imports.bool.ifThenElse isOptional "${k} ? «code»" k;
+      body = imports.string.intercalate ", " (imports.set.mapToValues showArg args);
+      withArgs = "{ " + body + " }: «code»";
+    in imports.bool.ifThenElse (args == { }) "«lambda»" withArgs;
+  };
+
+  lambda = mkType {
+    name = "lambda";
+    description = "lambda function";
+    check = builtins.isFunction;
+    inherit (function) show;
+  };
+
+  functionSet = mkType {
+    name = "function ${attrs.name}";
+    description = "callable ${attrs.description} function";
+    check = f: f ? __functor && function.check f.__functor && function.check (f.__functor f);
+    inherit (function) show;
+  };
 }


### PR DESCRIPTION
`show` could differentiate a `«functor»` from a primitive lambda if wanted, but I'm not sure if that's important. It might make more sense to just show `«function»` for both?

Requires #39