### PR TITLE
Add safer variants of partial operations

### DIFF
--- a/num.nix
+++ b/num.nix
@@ -353,7 +353,7 @@ in rec {
   /* toHexString :: int -> string
   */
   toHexString = x:
-    let toHexDigit = string.index "0123456789abcdef";
+    let toHexDigit = string.unsafeIndex "0123456789abcdef";
     in string.concatMap toHexDigit (toBaseDigits 16 x);
 
   /* gcd :: int -> int -> int
@@ -515,7 +515,7 @@ in rec {
           then shiftR x (-n)
         else if n >= bitSize
           then 0
-        else x * list.index powtab n;
+        else x * builtins.elemAt powtab n;
 
       /* shiftLU :: int -> int -> int
 
@@ -536,7 +536,7 @@ in rec {
           then shiftRU x (-n)
         else if n >= bitSize
           then 0
-        else x * list.index powtab n;
+        else x * builtins.elemAt powtab n;
 
       /* shiftR :: int -> int -> int
 
@@ -557,8 +557,8 @@ in rec {
         else if n >= bitSize
           then (if x < 0 then -1 else 0)
         else if x < 0
-          then ((x + minInt) / (list.index powtab n)) - list.index powtab (63 - n)
-        else x / list.index powtab n;
+          then ((x + minInt) / (builtins.elemAt powtab n)) - builtins.elemAt powtab (63 - n)
+        else x / builtins.elemAt powtab n;
 
       /* shiftRU :: int -> int -> int
 
@@ -578,8 +578,8 @@ in rec {
         else if n >= bitSize
           then 0
         else if x < 0
-          then ((x + minInt) / (list.index powtab n)) + list.index powtab (63 - n)
-        else x / list.index powtab n;
+          then ((x + minInt) / (builtins.elemAt powtab n)) + builtins.elemAt powtab (63 - n)
+        else x / builtins.elemAt powtab n;
 
       /* rotateL :: int -> int -> int
 
@@ -668,7 +668,7 @@ in rec {
             then 64
           else if x0 < 0 # MSB is set
             then 63
-          else list.index debruijn (shiftRU (x6 * 285870213051386505) 58);
+          else builtins.elemAt debruijn (shiftRU (x6 * 285870213051386505) 58);
 
       /* countLeadingZeros :: int -> int
 

--- a/regex.nix
+++ b/regex.nix
@@ -70,7 +70,7 @@ rec {
      [ "123" "456" ]
   */
   allMatches = regex: str:
-    list.concatMap (g: if builtins.isList g then [(list.head g)] else []) (split (capture regex) str);
+    list.concatMap (g: if builtins.isList g then [(builtins.head g)] else []) (split (capture regex) str);
 
   /* firstMatch :: regex -> string -> optional string
 
@@ -85,7 +85,7 @@ rec {
   firstMatch = regex: str:
     let res = split (capture regex) str;
     in if list.length res > 1
-      then optional.just (list.head (list.index res 1))
+      then optional.just (builtins.head (builtins.elemAt res 1))
       else optional.nothing;
 
   /* lastMatch :: regex -> string -> optional string
@@ -103,7 +103,7 @@ rec {
       res = split (capture regex) str;
       len = list.length res;
     in if len > 1
-      then optional.just (list.head (list.index res (len - 2)))
+      then optional.just (builtins.head (builtins.elemAt res (len - 2)))
       else optional.nothing;
 
   /* split :: regex -> string -> [string | [nullable string]]
@@ -175,7 +175,7 @@ rec {
         let
           replaceGroup = group:
             if builtins.isList group
-              then list.index captures (builtins.fromJSON (list.head group))
+              then builtins.elemAt captures (builtins.fromJSON (builtins.head group))
               else group;
         in string.concatMap replaceGroup subs;
     in substituteWith (capture regex) replaceCaptures;

--- a/set.nix
+++ b/set.nix
@@ -44,7 +44,7 @@ rec {
 
   # O(log(keys))
   match1 = o: { assign }:
-    let k = list.head (keys o);
+    let k = builtins.head (keys o);
         v = o."${k}";
         r = builtins.removeAttrs o [k];
     in assign k v r;

--- a/string.nix
+++ b/string.nix
@@ -47,17 +47,32 @@ rec {
   substring = builtins.substring;
 
   /* @partial
-     index :: string -> int -> string
+     unsafeIndex :: string -> int -> string
 
      Returns the nth character of a string. Fails if the index is out of bounds.
 
-     > string.index 3 "foobar"
+     > string.unsafeIndex 3 "foobar"
      "b"
   */
-  index = str: n:
-    if n >= length str
-      then throw "std.string.index: index out of bounds"
+  unsafeIndex = str: n:
+    if n < 0 || n >= length str
+      then throw "std.string.unsafeIndex: index out of bounds"
       else substring n 1 str;
+
+  /* index :: string -> int -> optional string
+
+     Returns the nth character of a string. Returns `optional.nothing` if the
+     string is empty.
+
+     > string.index 3 "foobar"
+     { _tag = "just"; value = "b"; }
+     > string.index (-1) "foobar"
+     { _tag = "nothing"; }
+  */
+  index = str: n:
+    if n < 0 || n >= length str
+      then _optional.nothing
+      else _optional.just (substring n 1 str);
 
   /* length :: string -> int
 
@@ -156,7 +171,7 @@ rec {
      > string.toChars "foo"
      [ "f" "o" "o" ]
   */
-  toChars = str: list.generate (index str) (length str);
+  toChars = str: list.generate (unsafeIndex str) (length str);
 
   /* map :: (string -> string) -> string -> string
 
@@ -188,7 +203,7 @@ rec {
       go = i:
         if i >= len
         then _optional.nothing
-        else if pred (index str i)
+        else if pred (unsafeIndex str i)
              then _optional.just i
              else go (i + 1);
     in go 0;
@@ -204,7 +219,7 @@ rec {
       go = i:
         if i < 0
         then _optional.nothing
-        else if pred (index str i)
+        else if pred (unsafeIndex str i)
              then _optional.just i
              else go (i - 1);
     in go (len - 1);
@@ -218,7 +233,7 @@ rec {
     let i = findIndex pred str;
     in if i._tag == "nothing"
        then _optional.nothing
-       else _optional.just (index str i.value);
+       else _optional.just (unsafeIndex str i.value);
 
   /* findLast :: (string -> bool) -> string -> Optional string
 
@@ -229,7 +244,7 @@ rec {
     let i = findLastIndex pred str;
     in if i._tag == "nothing"
        then _optional.nothing
-       else _optional.just (index str i.value);
+       else _optional.just (unsafeIndex str i.value);
 
   /* escape :: [string] -> string -> string
 
@@ -338,56 +353,104 @@ rec {
   optional = b: str: if b then str else "";
 
   /* @partial
-     head :: string -> string
+     unsafeHead :: string -> string
 
      Return the first character of the string.
 
      Fails if the string is empty.
   */
+  unsafeHead = str:
+    let len = length str;
+    in if len > 0
+      then unsafeIndex str 0
+      else throw "std.string.unsafeHead: empty string";
+
+  /* head :: string -> optional string
+
+     Return the first character of the string.
+
+     Returns `optional.nothing` if the string is empty.
+  */
   head = str:
     let len = length str;
     in if len > 0
-      then index str 0
-      else throw "std.string.head: empty string";
+      then _optional.just (unsafeIndex str 0)
+      else _optional.nothing;
 
   /* @partial
-     tail :: string -> string
+     unsafeTail :: string -> string
 
      Return the string minus the first character.
 
      Fails if the string is empty.
   */
-  tail = str:
+  unsafeTail = str:
     let len = length str;
     in if len > 0
       then substring 1 (len - 1) str
-      else throw "std.string.tail: empty string";
+      else throw "std.string.unsafeTail: empty string";
+
+  /* tail :: string -> optional string
+
+     Return the string minus the first character.
+
+     Returns `optional.nothing` if the string is empty.
+  */
+  tail = str:
+    let len = length str;
+    in if len > 0
+      then _optional.just (substring 1 (len - 1) str)
+      else _optional.nothing;
 
   /* @partial
-     init :: string -> string
+     unsafeInit :: string -> string
 
      Return the string minus the last character.
 
      Fails if the string is empty.
   */
-  init = str:
+  unsafeInit = str:
     let len = length str;
     in if len > 0
       then substring 0 (len - 1) str
-      else throw "std.string.init: empty string";
+      else throw "std.string.unsafeInit: empty string";
+
+  /* init :: string -> optional string
+
+     Return the string minus the last character.
+
+     Returns `optional.nothing` if the string is empty.
+  */
+  init = str:
+    let len = length str;
+    in if len > 0
+      then _optional.just (substring 0 (len - 1) str)
+      else _optional.nothing;
 
   /* @partial
-     last :: string -> string
+     unsafeLast :: string -> string
 
      Return the last character of a string.
 
      Fails if the string is empty.
   */
-  last = str:
+  unsafeLast = str:
     let len = length str;
     in if len > 0
       then substring (len  - 1) 1 str
-      else throw "std.string.last: empty string";
+      else throw "std.string.unsafeLast: empty string";
+
+  /* last :: string -> optional string
+
+     Return the last character of a string.
+
+     Returns `optional.nothing` if the string is empty.
+  */
+  last = str:
+    let len = length str;
+    in if len > 0
+      then _optional.just (substring (len  - 1) 1 str)
+      else _optional.nothing;
 
   /* take :: int -> string -> string
 

--- a/test/sections/list.nix
+++ b/test/sections/list.nix
@@ -95,11 +95,27 @@ section "std.list" {
     (assertEqual false (list.empty [null]))
   ];
 
-  head = assertEqual 10 (list.head [10 20 30]);
-  tail = assertEqual [20 30] (list.tail [10 20 30]);
-  init = assertEqual [10 20] (list.init [10 20 30]);
+  unsafeHead = assertEqual 10 (list.unsafeHead [10 20 30]);
+  unsafeTail = assertEqual [20 30] (list.unsafeTail [10 20 30]);
+  unsafeInit = assertEqual [10 20] (list.unsafeInit [10 20 30]);
+  unsafeLast = assertEqual 30 (list.unsafeLast [10 20 30]);
 
-  last = assertEqual 30 (list.last [10 20 30]);
+  head = string.unlines [
+    (assertEqual (optional.just 10) (list.head [10 20 30]))
+    (assertEqual optional.nothing (list.head []))
+  ];
+  tail = string.unlines [
+    (assertEqual (optional.just [20 30]) (list.tail [10 20 30]))
+    (assertEqual optional.nothing (list.tail []))
+  ];
+  init = string.unlines [
+    (assertEqual (optional.just [10 20]) (list.init [10 20 30]))
+    (assertEqual optional.nothing (list.init []))
+  ];
+  last = string.unlines [
+    (assertEqual (optional.just 30) (list.last [10 20 30]))
+    (assertEqual optional.nothing (list.last []))
+  ];
 
   take = let xs = list.range 1 20; in string.unlines [
     (assertEqual [1 2 3 4] (list.take 4 xs))
@@ -142,8 +158,12 @@ section "std.list" {
     (assertEqual [ 1 2 3 20 ] (list.insertAt 3 20 [ 1 2 3 ]))
   ];
   ifor = assertEqual ["foo-0" "bar-1"] (list.ifor ["foo" "bar"] (i: s: s + "-" + builtins.toString i));
-  elemAt = assertEqual "barry" (list.elemAt ["bar" "ry" "barry"] 2);
-  index = assertEqual "barry" (list.index ["bar" "ry" "barry"] 2);
+  unsafeIndex = assertEqual "barry" (list.unsafeIndex ["bar" "ry" "barry"] 2);
+  index = string.unlines [
+    (assertEqual (optional.just "barry") (list.index ["bar" "ry" "barry"] 2))
+    (assertEqual optional.nothing (list.index ["bar" "ry" "barry"] (-1)))
+    (assertEqual optional.nothing (list.index ["bar" "ry" "barry"] 3))
+  ];
   concat = assertEqual ["foo" "bar" "baz" "quux"] (list.concat [["foo"] ["bar"] ["baz" "quux"]]);
   filter = assertEqual ["foo" "fun" "friends"] (list.filter (string.hasPrefix "f") ["foo" "oof" "fun" "nuf" "friends" "sdneirf"]);
   elem = assertEqual builtins.true (list.elem "friend" ["texas" "friend" "amigo"]);

--- a/test/sections/nonempty.nix
+++ b/test/sections/nonempty.nix
@@ -141,8 +141,15 @@ section "std.nonempty" {
     (assertEqual (nonempty.make 20 [ 1 2 3 ]) (nonempty.insertAt 0 20 (nonempty.make 1 [ 2 3 ])))
     (assertEqual (nonempty.make 1 [ 2 3 20 ]) (nonempty.insertAt 3 20 (nonempty.make 1 [ 2 3 ])))
   ];
-  elemAt = assertEqual "barry" (nonempty.elemAt (nonempty.make "bar" ["ry" "barry"]) 2);
-  index = assertEqual "barry" (nonempty.index (nonempty.make "bar" ["ry" "barry"]) 2);
+  unsafeIndex = string.unlines [
+    (assertEqual "bar" (nonempty.unsafeIndex (nonempty.make "bar" ["ry" "barry"]) 0))
+    (assertEqual "barry" (nonempty.unsafeIndex (nonempty.make "bar" ["ry" "barry"]) 2))
+  ];
+  index = string.unlines [
+    (assertEqual (optional.just "bar") (nonempty.index (nonempty.make "bar" ["ry" "barry"]) 0))
+    (assertEqual (optional.just "barry") (nonempty.index (nonempty.make "bar" ["ry" "barry"]) 2))
+    (assertEqual optional.nothing (nonempty.index (nonempty.make "bar" ["ry" "barry"]) 3))
+  ];
   filter = assertEqual ["foo" "fun" "friends"] (nonempty.filter (string.hasPrefix "f") (nonempty.make "foo" ["oof" "fun" "nuf" "friends" "sdneirf"]));
   elem = assertEqual builtins.true (nonempty.elem "friend" (nonempty.make "texas" ["friend" "amigo"]));
   notElem = assertEqual builtins.true (nonempty.notElem "foo" (nonempty.make "texas" ["friend" "amigo"]));

--- a/test/sections/string.nix
+++ b/test/sections/string.nix
@@ -29,7 +29,12 @@ section "std.string" {
     (assertEqual (string.substring 10 5 "foobar") string.empty)
     (assertEqual (string.substring 1 (-20) "foobar") "oobar")
   ];
-  index = assertEqual (string.index "foobar" 3) "b";
+  unsafeIndex = assertEqual (string.unsafeIndex "foobar" 3) "b";
+  index = string.unlines [
+    (assertEqual (string.index "foobar" 3) (optional.just "b"))
+    (assertEqual (string.index "foobar" 6) optional.nothing)
+    (assertEqual (string.index "foobar" (-1)) optional.nothing)
+  ];
   length = assertEqual (string.length "foo") 3;
   empty = string.unlines [
     (assertEqual (string.isEmpty "a") false)
@@ -87,10 +92,26 @@ section "std.string" {
     (assertEqual (string.optional true "foo") "foo")
     (assertEqual (string.optional false "foo") string.empty)
   ];
-  head = assertEqual (string.head "bar") "b";
-  tail = assertEqual (string.tail "bar") "ar";
-  init = assertEqual (string.init "bar") "ba";
-  last = assertEqual (string.last "bar") "r";
+  unsafeHead = assertEqual (string.unsafeHead "bar") "b";
+  unsafeTail = assertEqual (string.unsafeTail "bar") "ar";
+  unsafeInit = assertEqual (string.unsafeInit "bar") "ba";
+  unsafeLast = assertEqual (string.unsafeLast "bar") "r";
+  head = string.unlines [
+    (assertEqual (string.head "bar") (optional.just "b"))
+    (assertEqual (string.head "") optional.nothing)
+  ];
+  tail = string.unlines [
+    (assertEqual (string.tail "bar") (optional.just "ar"))
+    (assertEqual (string.tail "") optional.nothing)
+  ];
+  init = string.unlines [
+    (assertEqual (string.init "bar") (optional.just "ba"))
+    (assertEqual (string.init "") optional.nothing)
+  ];
+  last = string.unlines [
+    (assertEqual (string.last "bar") (optional.just "r"))
+    (assertEqual (string.last "") optional.nothing)
+  ];
   take = string.unlines [
     (assertEqual (string.take 3 "foobar") "foo")
     (assertEqual (string.take 7 "foobar") "foobar")


### PR DESCRIPTION
Renames a bunch of partial functions and adds safe variants of the functions. For example, `list.head :: [a] -> a` is renamed to `list.unsafeHead :: [a] -> a`, and a `list.head :: [a] -> optional a` is added.

The callsites throughout the rest of the library have either been appropriately renamed or converted to a builtin where possible. This renaming certainly gave a lot of opaque type errors, but I think it's worth it in the long run. The biggest downside is the inconsistency with `builtins`; that is, `builtins.head` is partial while `list.head` is not.

For a similar reason, I also removed `list.elemAt` and `nonempty.elemAt` as synonyms for `index`; we could instead do the same renaming and have `unsafeElemAt` and `elemAt`, but i think sticking to one name would lead to less confusion.

Some other miscellaneous thoughts:

- The errors thrown by e.g. `list.unsafeHead` and `list.unsafeLast` are inconsistent right now, since one defers to `builtins.head` and the other throws an error mentioning `nix-std`; we may want to add explicit checks for more consistent error messages.
- We may want to reconsider some functions that throw on invalid input, like `(list|nonempty).insertAt` or `serde.toTOML`. For example, should `insertAt` throw, return an optional, or return an unchanged list?
- The `slice` and `substring` functions could also be improved a lot