### PR TITLE
num.pow using exponentiation by squaring

### DIFF
--- a/num.nix
+++ b/num.nix
@@ -118,13 +118,13 @@ in rec {
      Integer exponentiation. Note that this only handles positive integer exponents.
   */
   pow = base0: exponent0:
-    let pow' = base: exponent: value:
+    let pow' = x: exponent: res:
         if exponent == 0
-          then 1
-        else if exponent <= 1
-          then value
-        else pow' base (exponent - 1) (value * base);
-    in if base0 == 0 || base0 == 1 then 1 else pow' base0 exponent0 base0;
+          then res
+        else if bits.test exponent 0
+          then pow' x (bits.clear exponent 0) (res * x)
+        else pow' (x * x) (bits.shiftRU exponent 1) res;
+    in if base0 == 0 || base0 == 1 then 1 else pow' base0 exponent0 1;
 
   pi = 3.141592653589793238;
 

--- a/test/sections/num.nix
+++ b/test/sections/num.nix
@@ -73,6 +73,12 @@ section "std.num" {
   pow = string.unlines [
     (assertEqual (num.pow 0 10) 1)
     (assertEqual (num.pow 1 10) 1)
+    (assertEqual (num.pow  2 (-1)) 0) # Fraction 1/2 gets floored
+    (assertEqual (num.pow  2 0) 1)
+    (assertEqual (num.pow  2 1) 2)
+    (assertEqual (num.pow  2 10) 1024)
+    (assertEqual (num.pow  2 (num.bits.bitSize - 1)) num.minInt) # Overflow
+    (assertEqual (num.pow 5 3) 125)
     (assertEqual (num.pow 10 0) 1)
     (assertEqual (num.pow 10 1) 10)
     (assertEqual (num.pow 10 3) 1000)


### PR DESCRIPTION
This PR changes the naive method of computing the power of some number to the more efficient exponentiation by squaring.

It is likely that this is completely unnecessary as a change, as nix only supports single-precision 64 bit integers so far. If this changes at some time in the future, this would be more robust.

Tests remain successful for me.