### PR TITLE
evaluate all of lib as part of tests

### DIFF
--- a/test/default.nix
+++ b/test/default.nix
@@ -6,7 +6,7 @@ with std;
 
 with { sections = import ./sections/default.nix; };
 
-builtins.derivation {
+builtins.deepSeq std builtins.derivation {
   name = "nix-std-test-${import ./../version.nix}";
   inherit system;
   builder = "/bin/sh";


### PR DESCRIPTION
This would've caught issue #32, and will prevent similar bugs.

```bash
:; git revert 99d1254fc8bd966b48b1f77eee0e6e3df5e6ded6
Revert "nullable: fix undefined variable 'lift2'"
:; nix flake check
warning: unknown flake output 'lib'
error: undefined variable 'lift2'
at /nix/store/lzcpwm5dgmncbrql2gll4s40hi0d6ff4-source/nullable.nix:27:10:
27|     ap = lift2 id;
  |          ^