### PR TITLE
filling in more types

### DIFF
--- a/test/sections/list.nix
+++ b/test/sections/list.nix
@@ -5,18 +5,23 @@ with (import ./../framework.nix);
 
 section "std.list" {
   check = string.unlines [
+    (assertEqual true (types.list.check [ ]))
+    (assertEqual false (types.list.check { }))
     (assertEqual true ((types.listOf types.int).check [ ]))
     (assertEqual true ((types.listOf types.int).check [ 1 2 3 ]))
     (assertEqual false ((types.listOf types.int).check [ 1 2 "foo" ]))
   ];
   checkNonEmpty = string.unlines [
+    (assertEqual true (types.nonEmptyList.check [ 1 2 3 ]))
+    (assertEqual false (types.nonEmptyList.check [ ]))
+    (assertEqual false (types.nonEmptyList.check { }))
     (assertEqual true ((types.nonEmptyListOf types.int).check [ 1 2 3 ]))
     (assertEqual false ((types.nonEmptyListOf types.int).check [ 1 2 "foo" ]))
   ];
 
   show = string.unlines [
-    (assertEqual "[ ]" (types.show [ ]))
-    (assertEqual "[ 1, 2, 3 ]" (types.show [ 1 2 3 ]))
+    (assertEqual "[ ]" (types.list.show [ ]))
+    (assertEqual "[ 1, 2, 3 ]" (types.list.show [ 1 2 3 ]))
   ];
 
   laws = string.unlines [

--- a/test/sections/list.nix
+++ b/test/sections/list.nix
@@ -4,6 +4,21 @@ with std;
 with (import ./../framework.nix);
 
 section "std.list" {
+  check = string.unlines [
+    (assertEqual true ((types.listOf types.int).check [ ]))
+    (assertEqual true ((types.listOf types.int).check [ 1 2 3 ]))
+    (assertEqual false ((types.listOf types.int).check [ 1 2 "foo" ]))
+  ];
+  checkNonEmpty = string.unlines [
+    (assertEqual true ((types.nonEmptyListOf types.int).check [ 1 2 3 ]))
+    (assertEqual false ((types.nonEmptyListOf types.int).check [ 1 2 "foo" ]))
+  ];
+
+  show = string.unlines [
+    (assertEqual "[ ]" (types.show [ ]))
+    (assertEqual "[ 1, 2, 3 ]" (types.show [ 1 2 3 ]))
+  ];
+
   laws = string.unlines [
     (functor list.functor {
       typeName = "list";

--- a/test/sections/nonempty.nix
+++ b/test/sections/nonempty.nix
@@ -4,6 +4,21 @@ with std;
 with (import ./../framework.nix);
 
 section "std.nonempty" {
+  check = string.unlines [
+    (assertEqual true (types.nonEmpty.check (nonempty.make 3 [2 1])))
+    (assertEqual false (types.nonEmpty.check (nonempty.make 3 "foo")))
+    (assertEqual false (types.nonEmpty.check [ 1 ]))
+    (assertEqual false (types.nonEmpty.check (nonempty.make 3 [2 1] // { foo = "bar"; })))
+    (assertEqual true ((types.nonEmptyOf types.int).check (nonempty.make 3 [2 1])))
+    (assertEqual false ((types.nonEmptyOf types.int).check (nonempty.make 3 [2 "foo"])))
+    (assertEqual true ((types.nonEmptyListOf types.int).check (nonempty.toList (nonempty.make 3 [2 1]))))
+  ];
+
+  show = string.unlines [
+    (assertEqual "nonempty [ 0 ]" (types.nonEmpty.show (nonempty.make 0 [])))
+    (assertEqual "nonempty [ 0, 1 ]" (types.nonEmpty.show (nonempty.make 0 [1])))
+  ];
+
   laws = string.unlines [
     (functor nonempty.functor {
       typeName = "nonempty";

--- a/test/sections/nonempty.nix
+++ b/test/sections/nonempty.nix
@@ -17,6 +17,9 @@ section "std.nonempty" {
   show = string.unlines [
     (assertEqual "nonempty [ 0 ]" (types.nonEmpty.show (nonempty.make 0 [])))
     (assertEqual "nonempty [ 0, 1 ]" (types.nonEmpty.show (nonempty.make 0 [1])))
+    (assertEqual "{ foo = nonempty [ 0, 1 ]; }" ((types.attrsOf types.nonEmpty).show {
+      foo = nonempty.make 0 [1];
+    }))
   ];
 
   laws = string.unlines [

--- a/test/sections/set.nix
+++ b/test/sections/set.nix
@@ -6,6 +6,19 @@ with (import ./../framework.nix);
 let
   testSet = { a = 0; b = 1; c = 2; };
 in section "std.set" {
+  check = string.unlines [
+    (assertEqual true (types.attrs.check {}))
+    (assertEqual false (types.attrs.check []))
+    (assertEqual true ((types.attrsOf types.int).check testSet))
+    (assertEqual true ((types.attrsOf types.int).check {}))
+    (assertEqual false ((types.attrsOf types.int).check (testSet // { d = "foo"; })))
+  ];
+
+  show = string.unlines [
+    (assertEqual "{ a = 0; b = 1; c = 2; }" (types.attrs.show testSet))
+    (assertEqual "{ }" (types.attrs.show {}))
+  ];
+
   empty = assertEqual set.empty {};
   optional = string.unlines [
     (assertEqual set.empty (set.optional false testSet))

--- a/types.nix
+++ b/types.nix
@@ -20,7 +20,10 @@ let
   showFloat = builtins.toString;
   showFunction = const "<<lambda>>";
   showInt = builtins.toString;
-  showList = ls: "[ " + imports.string.concatSep ", " (imports.list.map showInternal ls) + " ]";
+  showList = ls:
+    let body = imports.string.intercalate ", " (imports.list.map showInternal ls);
+        tokens = [ "[" ] ++ imports.list.optional (! imports.list.empty ls) body ++ [ "]" ];
+    in imports.string.intercalate " " tokens;
   showNull = const "null";
   showPath = builtins.toString;
   showSet = s:

--- a/types.nix
+++ b/types.nix
@@ -5,6 +5,7 @@ with rec {
 
 let
   imports = {
+    bool = import ./bool.nix;
     list = import ./list.nix;
     nonempty = import ./nonempty.nix;
     num = import ./num.nix;
@@ -242,6 +243,7 @@ rec {
     name = "either";
     description = "${a.description} or ${b.description}";
     check = x: a.check x || b.check x;
+    show = x: imports.bool.ifThenElse (a.check x) a.show b.show x;
   };
 
   oneOf = types:


### PR DESCRIPTION
Introduces a bunch of type changes:
- `types.list` and `types.nonEmptyList` as untyped variants of `listOf` and `nonEmptyListOf`
- `types.nonEmpty` and `types.nonEmptyOf`
- `types.attrsOf` as a typed variant of `attrs`
- show for containers of other types uses the correct `t.show` instead of falling back to `showInternal`
- have `showInternal` use `type.x.show` instead of the other way around