### PR TITLE
std.path

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -27,6 +27,8 @@ rec {
 
   optional = import ./optional.nix;
 
+  path = import ./path.nix;
+
   regex = import ./regex.nix;
 
   semigroup = import ./semigroup.nix;

--- a/path.nix
+++ b/path.nix
@@ -1,0 +1,69 @@
+with rec {
+  string = import ./string.nix;
+  bool = import ./bool.nix;
+  types = import ./types.nix;
+};
+
+rec {
+  /* baseName :: string | path -> string
+
+     Returns everything following the final slash in a path, without
+     context. Typically, this corresponds to the file or directory name.
+
+     > path.baseName "/a/b/c"
+     "c"
+     > path.baseName /a/b/c
+     "c"
+  */
+  baseName = p: builtins.baseNameOf (
+    if types.path.check p then p
+    # NOTE: the builtin's behaviour is inconsistent when passed a path vs string, and
+    # it is nonsensical to retain string context for the stripped-off filename anyway.
+    else builtins.unsafeDiscardStringContext (toString p)
+  );
+
+  /* dirName :: string -> string
+
+     Returns the directory part of the path-like string, without context.
+
+     > path.dirName "/a/b/c"
+     "/a/b"
+     > path.dirName "a/b/c"
+     "a/b"
+  */
+  dirName = p: builtins.dirOf (builtins.unsafeDiscardStringContext (toString p));
+
+  /* parent :: path -> path
+     parent :: string -> string
+
+     Returns the directory part of the path.
+
+     > path.dirName "/a/b/c"
+     "/a/b"
+     > path.dirName /a/b/c
+     /a/b
+  */
+  parent = builtins.dirOf;
+
+  /* fromString :: string -> optional path
+
+     Casts a string into a path type. Returns `optional.nothing`
+     if the path is not absolute (it must start with a `/` to be valid).
+
+     > path.fromString "/a/b/c"
+     { _tag = "just"; value = /a/b/c; }
+     > path.fromString "a/b/c"
+     { _tag = "nothing"; }
+  */
+  fromString = s: bool.toOptional (string.hasPrefix "/" s) (unsafeFromString s);
+
+  /* unsafeFromString :: string -> path
+
+     Casts a string into a path type. The resulting path will be incorrect if
+     a relative path is provided.
+
+     > path.unsafeFromString "/a/b/c"
+     /a/b/c
+  */
+  unsafeFromString = s: /. + builtins.unsafeDiscardStringContext (toString s);
+}

--- a/test/sections/default.nix
+++ b/test/sections/default.nix
@@ -7,6 +7,7 @@
   nonempty = import ./nonempty.nix;
   num = import ./num.nix;
   optional = import ./optional.nix;
+  path = import ./path.nix;
   regex = import ./regex.nix;
   serde = import ./serde.nix;
   set = import ./set.nix;

--- a/test/sections/path.nix
+++ b/test/sections/path.nix
@@ -18,4 +18,23 @@ in section "std.path" {
     (assertEqual true (types.pathlike.check (toString ./foo.nix)))
     (assertEqual false (types.pathlike.check "a/b/c"))
   ];
+
+  baseName = string.unlines [
+    (assertEqual "foo.nix" (path.baseName ./foo.nix))
+    (assertEqual "path.nix" (path.baseName ./path.nix))
+    (assertEqual "foo.nix" (path.baseName (toString ./foo.nix)))
+    (assertEqual "-test" (string.substring 32 (-1) (path.baseName testDrv)))
+  ];
+
+  dirName = string.unlines [
+    (assertEqual ./. (path.parent ./foo.nix))
+    (assertEqual ./. (path.parent ./path.nix))
+    (assertEqual (toString ./.) (path.dirName (toString ./path.nix)))
+    (assertEqual (toString builtins.storeDir) (path.dirName testDrv))
+  ];
+
+  fromString = string.unlines [
+    (assertEqual (optional.just /a/b/c) (path.fromString "/a/b/c"))
+    (assertEqual optional.nothing (path.fromString "a/b/c"))
+  ];
 }

--- a/test/sections/path.nix
+++ b/test/sections/path.nix
@@ -1,0 +1,21 @@
+with { std = import ./../../default.nix; };
+with std;
+
+with (import ./../framework.nix);
+
+let
+  testDrv = builtins.derivation {
+    name = "test";
+    builder = "test";
+    system = "x86_64-linux";
+  };
+in section "std.path" {
+  check = string.unlines [
+    (assertEqual true (types.path.check ./foo.nix))
+    (assertEqual false (types.path.check (toString ./foo.nix)))
+    (assertEqual true (types.pathlike.check ./foo.nix))
+    (assertEqual true (types.pathlike.check testDrv))
+    (assertEqual true (types.pathlike.check (toString ./foo.nix)))
+    (assertEqual false (types.pathlike.check "a/b/c"))
+  ];
+}


### PR DESCRIPTION
It took a few steps to get here:
1. this splits up `types.path` into `types.pathlike`, depending on whether you strictly want type comparisons, or will accept any string that looks like a path.
2. `types.stringlike` is used as the base type for `types.pathlike`, because there are various types that can be considered paths (see `string.canCoerce`).

A few misc notes about the design:
- nix has different semantics when dealing with path types vs strings (`toString`, `${interpolation}`, coersion, `dirOf`), so I tried to normalize them where possible.
  - In particular, `builtins.baseNameOf` returns a contextual string if passed a string with context, but returns no context if passed a path (regardless of whether it exists or not). Given that `std.path` is meant to only manipulate paths (and not files), I think it makes sense to keep it consistent.
  - `builtins.dirOf` has similar behaviour, but it makes a little more sense to retain context here: the result of `path.parent "${pkgs.hello}/bin/hello` still refers to "${pkgs.hello}/bin" after all.
    - I've kept an explicit `path.dirName` variant that strips context, since "name" implies that the caller only cares about the string.
  - I'm open to suggestions here, since there's no obvious answer to some of these issues. Different names could help make things clearer too!
- Instead of `string` vs `stringlike`, `path` vs `pathlike`, `function` vs `lambda`/`functionSet`, you could adopt a naming scheme like:
  - `string` is anything coercible to a string
  - `string'` is strictly a `builtins.isString`
  - likewise for `path` and `path'`
  - `function'` could follow suit here to represent a lambda

See also: #42